### PR TITLE
Add missing context for Ed25519VerificationKey2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,14 +392,12 @@ key. Implementations of this specification will raise errors in the event of a
     "https://w3id.org/security/suites/ed25519-2020/v1"
   ],
   "id": "did:example:123",
-  "verificationMethod": [
-    {
-      "id": "did:example:123#key-0",
-      "type": "Ed25519VerificationKey2020",
-      "controller": "did:example:123",
-      "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
-    }
-  ],
+  "verificationMethod": [{
+    "id": "did:example:123#key-0",
+    "type": "Ed25519VerificationKey2020",
+    "controller": "did:example:123",
+    "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+  }],
   "authentication": [
     "did:example:123#key-0"
   ],

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
             key.
           </p>
 
-          <pre class="example">
+          <pre class="example" title="Ed25519VerificationKey2020 as JSON.">
             {
               "id": "https://example.com/issuer/123#key-0",
               "type": "Ed25519VerificationKey2020",
@@ -360,10 +360,12 @@
             }
           </pre>
 
-          <pre class="example" title="Example in DID Document.">
+          <pre class="example" title="Ed25519VerificationKey2020 in a DID Document.">
             {
               "@context": [
                 "https://www.w3.org/ns/did/v1",
+                "https://w3id.org/security/v1",
+                "https://w3id.org/security/suites/ed25519-2020/v1",
                 {
                   "@base": "did:example:123"
                 }

--- a/index.html
+++ b/index.html
@@ -364,7 +364,6 @@
             {
               "@context": [
                 "https://www.w3.org/ns/did/v1",
-                "https://w3id.org/security/v1",
                 "https://w3id.org/security/suites/ed25519-2020/v1",
                 {
                   "@base": "did:example:123"

--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
                 }
               ],
               "id": "did:example:123",
-              "publicKey": [
+              "verificationMethod": [
                 {
                   "id": "#key-0",
                   "type": "Ed25519VerificationKey2020",


### PR DESCRIPTION
In its current form, the example DID document that is supposed to represent an Ed25519VerificationKey2020 usable for various purposes contains the following statements:

```ttl
<did:example:123> <https://w3id.org/security#assertionMethod> <did:example:123#key-0> .
<did:example:123> <https://w3id.org/security#authenticationMethod> <did:example:123#key-0> .
<did:example:123> <https://w3id.org/security#capabilityDelegationMethod> <did:example:123#key-0> .
<did:example:123> <https://w3id.org/security#capabilityInvocationMethod> <did:example:123#key-0> .
```

The missing contexts add the statements describing the public key:

```ttl
# Public key pointer
<did:example:123> <https://w3id.org/security#publicKey> <did:example:123#key-0> .

# Valid usage (only existing statements currently)
<did:example:123> <https://w3id.org/security#assertionMethod> <did:example:123#key-0> .
<did:example:123> <https://w3id.org/security#authenticationMethod> <did:example:123#key-0> .
<did:example:123> <https://w3id.org/security#capabilityDelegationMethod> <did:example:123#key-0> .
<did:example:123> <https://w3id.org/security#capabilityInvocationMethod> <did:example:123#key-0> .

# Public key description
<did:example:123#key-0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519VerificationKey2020> .
<did:example:123#key-0> <https://w3id.org/security#controller> <did:example:123> .
<did:example:123#key-0> <https://w3id.org/security#publicKeyMultibase> "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"^^<https://w3id.org/security#multibase> .
```