### PR TITLE
DID document public keys are verification methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@
                 }
               ],
               "id": "did:example:123",
-              "publicKey": [
+              "verificationMethod": [
                 {
                   "id": "#key-0",
                   "type": "Ed25519VerificationKey2020",


### PR DESCRIPTION
I think there was a typo in [ed25519verificationkey2020](https://w3c-ccg.github.io/di-eddsa-2020/#ed25519verificationkey2020)'s [example 2](https://w3c-ccg.github.io/di-eddsa-2020/#example-example-in-did-document).

Public key material in DID documents should be exposed as [verification methods](https://www.w3.org/TR/did-core/#verification-methods), not as public keys.