### PR TITLE
Added test vectors for the Ed25519Signature2020 case.

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,150 +814,161 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
 
     <section class="appendix">
       <h2>Test Vectors</h2>
+      <section>
+        <h3>Representation: Ed25519Signature2020</h3>
+        <p>
+The signer needs to generate a private/public key pair with the private key used 
+for signing and the public key made available for verification. Below the 
+[[MULTIBASE]]/[[MULTICODEC]] representation for the public key, <code>ed25519-pub</code>,
+and the representation for the private key, <code>ed25519-priv</code>, are shown.
+        </p>
+        <pre class="example" title="Private and Public keys for Signature">
+{
+    publicKeyMultibase: "z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ2", 
+    privateKeyMultibase: "z3u2en7t5LR2WtQH5PfFqMqwVHBeXouLzo6haApm8XHqvjxq" 
+}
+        </pre>
+
+        <p>
+The signing begins with a credential without an attached proof which is then converted 
+to canonical form and then hashed as shown in the following three examples.
+        </p>
+
+        <pre class="example" title="Credential without Proof">
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "issuer": "https://example.edu/issuers/565049",
+  "issuanceDate": "2010-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  }
+}
+        </pre>
+      
+        <pre class="example" title="Canonical Credential without Proof">
+          &lt;did:example:ebfeb1f712ebc6f1c276e12ec21&gt; &lt;https://example.org/examples#degree&gt; _:c14n0 .
+          &lt;http://example.edu/credentials/3732&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://example.org/examples#UniversityDegreeCredential&gt; .
+          &lt;http://example.edu/credentials/3732&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2018/credentials#VerifiableCredential&gt; .
+          &lt;http://example.edu/credentials/3732&gt; &lt;https://www.w3.org/2018/credentials#credentialSubject&gt; &lt;did:example:ebfeb1f712ebc6f1c276e12ec21&gt; .
+          &lt;http://example.edu/credentials/3732&gt; &lt;https://www.w3.org/2018/credentials#issuanceDate&gt; &quot;2010-01-01T00:00:00Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; .
+          &lt;http://example.edu/credentials/3732&gt; &lt;https://www.w3.org/2018/credentials#issuer&gt; &lt;https://example.edu/issuers/565049&gt; .
+          _:c14n0 &lt;http://schema.org/name&gt; &quot;Bachelor of Science and Arts&quot;^^&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML&gt; .
+          _:c14n0 &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://example.org/examples#BachelorDegree&gt; .
+      </pre>
+
+      <pre class="example" title="Hash of Canonical Credential without Proof (hex)">
+6c6b2795e7fa33a9fb28062527142b3c6edf7ba239942439b6f0bb0851b3cce3
+      </pre>
+
       <p>
-The following test vectors are provided to assist with implementers.
+The next step is to take the proof options document, convert it to canonical form,
+and obtain its hash as shown in the next three examples.
       </p>
 
-      <pre class="example">
+      <pre class="example" title="Proof Options Document">
 {
-  "seed_0": "9b937b81322d816cfab9d5a3baacc9b2a5febe4b149f126b3630f93a29527017"
+  "type": "Ed25519Signature2020",
+  "created": "2022-12-07T21:31:08Z",
+  "verificationMethod": "https://example.edu/issuers/565049#key-1",
+  "proofPurpose": "assertionMethod",
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ]
 }
       </pre>
-      <pre class="example">
+
+      <pre class="example" title="Canonical Proof Options Document">
+_:c14n0 &lt;http://purl.org/dc/terms/created&gt; &quot;2022-12-07T21:31:08Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; .
+_:c14n0 &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://w3id.org/security#Ed25519Signature2020&gt; .
+_:c14n0 &lt;https://w3id.org/security#proofPurpose&gt; &lt;https://w3id.org/security#assertionMethod&gt; .
+_:c14n0 &lt;https://w3id.org/security#verificationMethod&gt; &lt;https://example.edu/issuers/565049#key-1&gt; .
+      </pre>
+
+      <pre class="example" title="Hash of Canonical Proof Options Document (hex)">
+565a2884ebb2d38aa34871108074ab51631ec812d33eb2473178bce19937ad09
+      </pre>
+
+      <p>
+Finally we combine the two hashes, use the private key with the combined hash to
+compute the Ed25519 signature, and then base58-btc encode the signature.
+to obtain  
+      </p>
+
+      <pre class="example" title="Combine hashes of Proof Options and Credential (hex)">
+565a2884ebb2d38aa34871108074ab51631ec812d33eb2473178bce19937ad096c6b2795e7fa33a9fb28062527142b3c6edf7ba239942439b6f0bb0851b3cce3
+      </pre>
+
+      <pre class="example" title="Signature of Combined Hashes (hex)">
+473fb02a4aaf5863a2ef33f104bd55617e40907bc311e29e87278d15d7596f201639f41ec0e00db11159e9139f673d9257558e1f0134e1f67ac73f91ed89670b
+      </pre>
+
+      <pre class="example" title="Signature of Combined Hashes base58-btc">
+z2RczMj342tVhAjgjEPV4TeHbi2ggnTRKTc5BFQCgaWJ3nhcg5HgCeC2eV4Lc1fYdhfoLyPjxoq4BtqrsyNvxZ8nE
+      </pre>
+
+      <p>Assemble the signed credential by:</p>
+      <ol>
+        <li>
+Adding the <code>proofValue</code> field with the previously computed base58-btc 
+value to the proof options document.
+        </li>
+        <li>
+Setting the <code>proof</code> field of the credential to the augmented proof 
+option document.
+        </li>
+      </ol>
+
+      <pre class="example" title="Signed Credential">
 {
-  "keypair_0": {
-    "id": "https://example.com/issuer/123#key-0",
-    "type": "Ed25519VerificationKey2018",
-    "controller": "https://example.com/issuer/123",
-    "publicKeyBase58": "dbDmZLTWuEYYZNHFLKLoRkEX4sZykkSLNQLXvMUyMB1",
-    "privateKeyBase58": "47QbyJEDqmHTzsdg8xzqXD8gqKuLufYRrKWTmB7eAaWHG2EAsQ2GUyqRqWWYT15dGuag52Sf3j4hs2mu7w52mgps"
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "issuer": "https://example.edu/issuers/565049",
+  "issuanceDate": "2010-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
   },
-  "keypair_1": {
-    "id": "https://example.com/issuer/123#key-0",
-    "type": "Ed25519KeyPair2020",
-    "controller": "https://example.com/issuer/123",
-    "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP",
-    "privateKeyMultibase": "zrv3kJcnBP1RpYmvNZ9jcYpKBZg41iSobWxSg3ix2U7Cp59kjwQFCT4SZTgLSL3HP8iGMdJs3nedjqYgNn6ZJmsmjRm"
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2022-12-07T21:31:08Z",
+    "verificationMethod": "https://example.edu/issuers/565049#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z2RczMj342tVhAjgjEPV4TeHbi2ggnTRKTc5BFQCgaWJ3nhcg5HgCeC2eV4Lc1fYdhfoLyPjxoq4BtqrsyNvxZ8nE"
   }
 }
       </pre>
 
-      <pre class="example">
-{
-  "issuer_0": {
-    "@context": [
-      "https://www.w3.org/ns/did/v1",
-      "https://w3id.org/security/suites/ed25519-2020/v1",
-      {
-        "@base": "https://example.com/issuer/123"
-      }
-    ],
-    "id": "https://example.com/issuer/123",
-    "verificationMethod": [
-      {
-        "id": "#key-0",
-        "type": "Ed25519VerificationKey2020",
-        "controller": "https://example.com/issuer/123",
-        "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
-      }
-    ],
-    "assertionMethod": ["#key-0"],
-    "authentication": ["#key-0"]
-  }
-}
-      </pre>
-
-      <pre class="example">
-{
-  "vc_template_0": {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://www.w3.org/2018/credentials/examples/v1",
-      "https://w3id.org/security/suites/ed25519-2020/v1",
-    ],
-    "id": "http://example.gov/credentials/3732",
-    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-    "issuer": "https://example.com/issuer/123",
-    "issuanceDate": "2020-03-10T04:24:12.164Z",
-    "credentialSubject": {
-      "id": "did:example:456",
-      "degree": {
-        "type": "BachelorDegree",
-        "name": "Bachelor of Science and Arts"
-      }
-    }
-  },
-  "vc_0": {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://www.w3.org/2018/credentials/examples/v1",
-      "https://w3id.org/security/suites/ed25519-2020/v1"
-    ],
-    "id": "http://example.gov/credentials/3732",
-    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-    "issuer": "https://example.com/issuer/123",
-    "issuanceDate": "2020-03-10T04:24:12.164Z",
-    "credentialSubject": {
-      "id": "did:example:456",
-      "degree": {
-        "type": "BachelorDegree",
-        "name": "Bachelor of Science and Arts"
-      }
-    },
-    "proof": {
-      "type": "Ed25519Signature2020",
-      "created": "2019-12-11T03:50:55Z",
-      "proofValue": "z5SpZtDGGz5a89PJbQT2sgbRUiyyAGhhgjcf86aJHfYcfvPjxn6vej5na6kUzmw1jMAR9PJU9mowshQFFdGmDN14D",
-      "proofPurpose": "assertionMethod",
-      "verificationMethod": "https://example.com/issuer/123#key-0"
-    }
-  },
-  "vp_0": {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/security/suites/ed25519-2020/v1"
-    ],
-    "type": ["VerifiablePresentation"],
-    "verifiableCredential": [
-      {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://www.w3.org/2018/credentials/examples/v1",
-          "https://w3id.org/security/suites/ed25519-2020/v1"
-        ],
-        "id": "http://example.gov/credentials/3732",
-        "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-        "issuer": "https://example.com/issuer/123",
-        "issuanceDate": "2020-03-10T04:24:12.164Z",
-        "credentialSubject": {
-          "id": "did:example:456",
-          "degree": {
-            "type": "BachelorDegree",
-            "name": "Bachelor of Science and Arts"
-          }
-        },
-        "proof": {
-          "type": "Ed25519Signature2020",
-          "created": "2019-12-11T03:50:55Z",
-          "proofValue": "z5SpZtDGGz5a89PJbQT2sgbRUiyyAGhhgjcf86aJHfYcfvPjxn6vej5na6kUzmw1jMAR9PJU9mowshQFFdGmDN14D",
-          "proofPurpose": "assertionMethod",
-          "verificationMethod": "https://example.com/issuer/123#key-0"
-        }
-      }
-    ],
-    "id": "urn:uuid:83895ddf-52ee-4408-8796-51a1856dbbec",
-    "holder": "did:ex:12345",
-    "proof": {
-      "type": "Ed25519Signature2020",
-      "created": "2021-06-04T20:50:09Z",
-      "verificationMethod": "https://example.com/issuer/123#key-0",
-      "proofPurpose": "authentication",
-      "challenge": "123",
-      "proofValue": "z2y3UBXAiToXLzQqeMnHiMozJ3hKxcMgLm7p8GRQA92F6JSYu49RxHQf6k1CMKnMdpj3BLRSH69b9qA9cfjE3oS7q"
-    }
-  }
-}
-      </pre>
+    </section>
+      <section>
+        <h3>Representation: DataIntegrityProof</h3>
+        <p>To be written...</p>
+      </section>
     </section>
 
   </body>


### PR DESCRIPTION
Added a set of test vectors for the `"type": "Ed25519Signature2020"` case to Appendix A. Let me know if this is the approach we'd like to use.

Cheers
Greg B.