### PR TITLE
Add json-eddsa-2022 cryptosuite.

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,10 +813,24 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
       </section>
 
       <section>
-        <h3>json-eddsa-2022</h3>
+        <h3>jcs-eddsa-2022</h3>
+
+          <p class="issue" title="Cryptosuite naming convention is disputed">
+The naming convention utilized by this cryptosuite is disputed. An alternative
+of `json-eddsa-2022` was originally suggested for this cryptography suite to
+convey that it is a cryptography suite for securing JSON data utilizing the
+Twisted Edwards Curve Digital Signature Algorithm. The counter-argument to
+the original proposal was that expressing the canonicalization mechanism in
+the cryptosuite string clearly conveys to a developer that the thing that
+differentiates this cryptosuite from the `eddsa-2022` one is the use of
+JSON Canonicalization Scheme [[RFC8785]]. Other options include
+`"cryptosuite": "json-sign-2022"`, and `"cryptosuite": "json-2022"`. This
+topic is <a href="https://github.com/w3c/vc-data-integrity/issues/38">
+currently being debated in the Data Integrity work item.</a>.
+          </p>
 
           <p>
-The `json-eddsa-2022` cryptographic suite takes an input document, canonicalizes
+The `jcs-eddsa-2022` cryptographic suite takes an input document, canonicalizes
 the document using the JSON Canonicalization Scheme [[RFC8785]], and then
 cryptographically hashes and signs the output resulting in the production of a
 data integrity proof. The algorithms for this cryptographic suite are the
@@ -833,7 +847,7 @@ and step <strong>2)</strong> are replaced by the following text:
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `json-eddsa-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `jcs-eddsa-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -595,7 +595,7 @@ into a transformed document that is ready to be provided as input to the
 hashing algorithm in Section <a href="#hashing-eddsa-2022"></a>.
           </p>
 
-
+          <p>
 Required inputs to this algorithm are an
 <a href="https://w3c.github.io/vc-data-integrity/#dfn-unsecured-data-document">
 unsecured data document</a> (<var>unsecuredDocument</var>) and
@@ -810,6 +810,48 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
           </ol>
 
         </section>
+      </section>
+
+      <section>
+        <h3>json-eddsa-2022</h3>
+
+          <p>
+The `json-eddsa-2022` cryptographic suite takes an input document, canonicalizes
+the document using the JSON Canonicalization Scheme [[RFC8785]], and then
+cryptographically hashes and signs the output resulting in the production of a
+data integrity proof. The algorithms for this cryptographic suite are the
+same as the ones in Section <a href="#eddsa-2022"></a> except for the following
+modifications:
+          </p>
+
+          <p>
+In Section <a href="#transformation-eddsa-2022"></a>, step <strong>1)</strong>
+and step <strong>2)</strong> are replaced by the following text:
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `json-eddsa-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+            </li>
+          </ol>
+
+          <p>
+In Section <a href="#proof-configuration-eddsa-2022"></a>, step
+<strong>4)</strong> is replaced by the following text:
+          </p>
+
+          <p style="padding-left: 2em;">
+<strong>4)</strong> If <var>options</var>.<var>type</var> is not set to
+`DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
+set to `json-eddsa-2020`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+          </p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,14 @@
           companyURL: "https://digitalcredentials.mit.edu/"
         }],
 
+        authors: [{
+          name: "Dave Longley", url: "http://digitalbazaar.com/",
+          company: "Digital Bazaar", companyURL: "http://digitalbazaar.com/"
+        }, {
+          name: "Manu Sporny", url: "https://www.linkedin.com/in/manusporny/",
+          company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"
+        }],
+
         github: "https://github.com/w3c/vc-di-eddsa/",
 
         // URI of the patent status for this WG, for Rec-track documents


### PR DESCRIPTION
Per [the discussion during the VCWG in-person meeting in Miami](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-02-15-vcwg#section1-2), the `jws-2020` cryptosuite was going to support JCS, but since EdDSA and ECDSA cryptosuites were going to also concretely support the feature, a decision was made to abandon the jws-2020 cryptosuite and merge the JCS featureset into the Data Integrity cryptosuites. 

This PR concretely adds the JCS functionality into the EdDSA Cryptosuite.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/pull/26.html" title="Last updated on Apr 4, 2023, 2:29 PM UTC (af98f82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/26/366354c...af98f82.html" title="Last updated on Apr 4, 2023, 2:29 PM UTC (af98f82)">Diff</a>