### PR TITLE
Add proof configuration canonicalization to algorithm steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,9 +618,6 @@ Universal RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]] to the <var>unsecuredDocument</var>.
             </li>
             <li>
-Set <var>output</var> to the value of <var>canonicalDocument</var>.
-            </li>
-            <li>
 Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
             </li>
           </ol>
@@ -639,8 +636,8 @@ Section <a href="#proof-verification-eddsa-2022"></a>.
 
           <p>
 The required inputs to this algorithm are a <em>transformed data document</em>
-(<var>transformedDocument</var>) and <em>proof configuration</em>
-(<var>proofConfig</var>). A single <em>hash data</em> value represented as
+(<var>transformedDocument</var>) and <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
 series of bytes is produced as output.
           </p>
 
@@ -654,7 +651,7 @@ be exactly 32 bytes in size.
             <li>
 Let <var>proofConfigHash</var> be the result of applying the
 SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>proofConfig</var>. <var>proofConfigHash</var> will be
+to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
 exactly 32 bytes in size.
             </li>
             <li>
@@ -718,7 +715,16 @@ Set <var>proofConfig</var>.<var>proofPurpose</var> to
 <var>options</var>.<var>proofPurpose</var>.
             </li>
             <li>
-Return <var>proofConfig</var>.
+Set <var>proofConfig</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
             </li>
           </ol>
 


### PR DESCRIPTION
For the `cryptosuite: eddsa-2022` I updated the algorithm sections with one small editorial fix and missing steps of "proof configuration canonicalization" (prior to hashing). The changes are summarized below.

*  In section 3.1.3 Transformation (eddsa-2022). Don't need both (3) Set output to the value of canonicalDocument. and (4) Return canonicalDocument as the transformed data document. These amount to the same thing. So removed old step 3.
*  In section 3.1.5 Proof Configuration (eddsa-2022). We need to add the `@context` field and canonize the proofConfig. I called this `canonicalProofConfig`
*  In section 3.1.4 Hashing (eddsa-2022). Update to use `canonicalProofConfig`
  
Note that the proof verification steps are incomplete with regard to reconstruction of the `proofConfig` to be canonized and hash. This seems to affect section 3.1.2 Verify Proof (eddsa-2022), which refers to section 3.1.7 Proof Verification (eddsa-2022), which refers back to  [VC-DATA-INTEGRITY] specification, Section 4: Algorithms which is incomplete in this regard.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/31.html" title="Last updated on Mar 17, 2023, 6:56 PM UTC (529805c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/31/a6ed18b...Wind4Greg:529805c.html" title="Last updated on Mar 17, 2023, 6:56 PM UTC (529805c)">Diff</a>