### PR TITLE
Fix eddsa-2022 typos.

### DIFF
--- a/index.html
+++ b/index.html
@@ -616,7 +616,7 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-2020` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `eddsa-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>
@@ -708,7 +708,7 @@ If <var>options</var>.<var>cryptosuite</var> is set, set
             </li>
             <li>
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
-<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-2020`, an
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-2022`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>


### PR DESCRIPTION
These look to be simple year typos.  There's also a `json-eddsa-2020` string which may be a typo?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-di-eddsa/pull/37.html" title="Last updated on Apr 19, 2023, 8:25 PM UTC (427805f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/37/f839914...davidlehn:427805f.html" title="Last updated on Apr 19, 2023, 8:25 PM UTC (427805f)">Diff</a>