### PR TITLE
`an Ed25519`, not `a Ed25519`

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@ The `controller` of the verification method MUST be a URL.
           <p>
 The `publicKeyMultibase` property of the verification method MUST be
 a public key encoded according to [[MULTICODEC]] and formatted according to
-[[MULTIBASE]]. The multicodec encoding of a Ed25519 public key is the two-byte
+[[MULTIBASE]]. The multicodec encoding of an Ed25519 public key is the two-byte
 prefix `0xed01` followed by the 32-byte public key data. The 34 byte
 value is then encoded using base58-btc (`z`) as the prefix. Any other encoding
 MUST NOT be allowed.
@@ -776,7 +776,7 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
             <p>
   The `publicKeyMultibase` property of the verification method MUST be
   a public key encoded according to [[MULTICODEC]] and formatted according to
-  [[MULTIBASE]]. The multicodec encoding of a Ed25519 public key is the two-byte
+  [[MULTIBASE]]. The multicodec encoding of an Ed25519 public key is the two-byte
   prefix `0xed01` followed by the 32-byte public key data. The 34 byte
   value is then encoded using base58-btc (`z`) as the prefix. Any other encoding
   MUST NOT be allowed.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-di-eddsa/pull/40.html" title="Last updated on Apr 21, 2023, 4:17 PM UTC (e985515)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/40/14022e4...TallTed:e985515.html" title="Last updated on Apr 21, 2023, 4:17 PM UTC (e985515)">Diff</a>