### PR TITLE
Update Sig2020 appendix for proof canonicalization.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,7 +1016,7 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
               <li>
   Let <var>proofConfigHash</var> be the result of applying the
   SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-  to the <var>proofConfig</var>. <var>proofConfigHash</var> will be
+  to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
   exactly 32 bytes in size.
               </li>
   
@@ -1080,8 +1080,17 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
   <var>options</var>.<var>proofPurpose</var>.
               </li>
               <li>
-  Return <var>proofConfig</var>.
+  Set <var>proofConfig</var>.<var>@context</var> to
+  <var>unsecuredDocument</var>.<var>@context</var>
               </li>
+              <li>
+  Let <var>canonicalProofConfig</var> be the result of applying the
+  Universal RDF Dataset Canonicalization Algorithm
+  [[RDF-CANON]] to the <var>proofConfig</var>.
+              </li>
+              <li>
+  Return <var>canonicalProofConfig</var>.
+              </li>  
             </ol>
   
           </section>


### PR DESCRIPTION
Appendix A "The Ed25519Signature2020 Suite" is missing the canonicalization step for the *proof configuration*. This PR add the relevant steps and update. These steps are essentially the same as used in section "3.1.5 Proof Configuration (eddsa-2022)" and are necessary to conform with existing implementations and test vectors


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/42.html" title="Last updated on Apr 26, 2023, 5:42 PM UTC (b696cb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/42/14022e4...Wind4Greg:b696cb1.html" title="Last updated on Apr 26, 2023, 5:42 PM UTC (b696cb1)">Diff</a>