### PR TITLE
Update JCS to fix proof configuration.

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,8 +688,8 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
           </ol>
 
           <p>
-In Section <a href="#proof-configuration-eddsa-2022"></a>, step <strong>8)</strong> is not performed, step
-<strong>4)</strong> and step <strong>9)</strong> are replaced by the following text:
+In Section <a href="#proof-configuration-eddsa-2022"></a>, step <strong>8)</strong> is not performed, and steps
+<strong>4)</strong> and <strong>9)</strong> are replaced by the following text:
           </p>
 
           <p style="padding-left: 2em;">

--- a/index.html
+++ b/index.html
@@ -688,14 +688,18 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
           </ol>
 
           <p>
-In Section <a href="#proof-configuration-eddsa-2022"></a>, step
-<strong>4)</strong> is replaced by the following text:
+In Section <a href="#proof-configuration-eddsa-2022"></a>, step <strong>8)</strong> is not performed, step
+<strong>4)</strong> and step <strong>9)</strong> are replaced by the following text:
           </p>
 
           <p style="padding-left: 2em;">
 <strong>4)</strong> If <var>options</var>.<var>type</var> is not set to
 `DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `json-eddsa-2020`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+set to `jcs-eddsa-2020`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+          </p>
+          <p style="padding-left: 2em;">
+<strong>9)</strong> Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
           </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -695,7 +695,7 @@ In Section <a href="#proof-configuration-eddsa-2022"></a>, step <strong>8)</stro
           <p style="padding-left: 2em;">
 <strong>4)</strong> If <var>options</var>.<var>type</var> is not set to
 `DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `jcs-eddsa-2020`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+set to `jcs-eddsa-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
           </p>
           <p style="padding-left: 2em;">
 <strong>9)</strong> Let <var>canonicalProofConfig</var> be the result of applying the


### PR DESCRIPTION
This PR fixes the issues raised in https://github.com/w3c/vc-di-eddsa/issues/41. In particular:

* Don't need to add document `@context` into *proofConfig* for canonicalization.
* Use the JCS canonicalization scheme and not RDF canonicalization.
* Fix name "jcs-eddsa-2022".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/43.html" title="Last updated on Apr 27, 2023, 4:58 PM UTC (7ab867e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/43/14022e4...Wind4Greg:7ab867e.html" title="Last updated on Apr 27, 2023, 4:58 PM UTC (7ab867e)">Diff</a>