### PR TITLE
Security Considerations: Added text on Ed25519 security properties.

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,9 +746,9 @@ mitigate the attacks.
 
       <section class="informative">
         <h3>Security Properties of Ed25519 Implementations</h3>
-        <p>There has 
-been wide adoption of Ed25519 signatures (EdDSA algorithm with edwards25519 
-curve) due to the compact size of the keys and signatures, and the speed at 
+        <p>Ed25519 signatures (EdDSA algorithm with edwards25519 curve) have
+        been widely adopted, due both to the compact size of the keys and
+        signatures and to the speed at 
 which signatures can be produced and verified. Many libraries exist that can
 create and verify Ed25519 signatures. Since the publication of [[RFC8032]] 
 security properties of Ed25519 signatures have been rigorously proven 

--- a/index.html
+++ b/index.html
@@ -753,7 +753,7 @@ which signatures can be produced and verified. Many libraries exist that can
 create and verify Ed25519 signatures. Since the publication of [[RFC8032]],
 security properties of Ed25519 signatures have been rigorously proven (see
 [[Provable_Ed25519]] and [[Taming_EdDSAs]]). However, it has been observed that a
-significant number of libraries do not achieve these security properties due to 
+significant number of libraries do not achieve these security levels, due to 
 missing input validity checks during the signature verification process. In 
 this section we summarize the security properties achievable with Ed25519 
 signatures and indicate how one can determine if a library will support those 

--- a/index.html
+++ b/index.html
@@ -751,8 +751,8 @@ mitigate the attacks.
         signatures and to the speed at 
 which signatures can be produced and verified. Many libraries exist that can
 create and verify Ed25519 signatures. Since the publication of [[RFC8032]],
-security properties of Ed25519 signatures have been rigorously proven 
-[[Provable_Ed25519]] and [[Taming_EdDSAs]]. However it was observed that a 
+security properties of Ed25519 signatures have been rigorously proven (see
+[[Provable_Ed25519]] and [[Taming_EdDSAs]]). However, it has been observed that a
 significant number of libraries do not achieve these security properties due to 
 missing input validity checks during the signature verification process. In 
 this section we summarize the security properties achievable with Ed25519 

--- a/index.html
+++ b/index.html
@@ -86,6 +86,21 @@
             title: "Multicodec",
             href: "https://github.com/multiformats/multicodec/",
           },
+          Taming_EdDSAs: {
+            title: "Taming the many EdDSAs",
+            href: "https://eprint.iacr.org/2020/1244",
+            authors: ["Konstantinos Chalkias", "François Garillot", "Valeria Nikolaenko"],
+            date: "2020",
+            publisher: "Cryptology ePrint Archive, Paper 2020/1244",
+            doi: "10.1007/978-3-030-64357-7_4"
+          },
+          Provable_Ed25519: {
+            authors: ["Jacqueline Brendel", "Cas Cremers", "Dennis Jackson", "Mang Zhao"],
+            title: "The Provable Security of Ed25519: Theory and Practice",
+            publisher: "Cryptology ePrint Archive, Paper 2020/823",
+            date: "2020",
+            href: "https://eprint.iacr.org/2020/823"
+          }
         },
         lint: {"no-unused-dfns": false},
         postProcess: [restrictRefs]
@@ -728,6 +743,561 @@ known mis-implementation attacks against multiple flavors of EdDSA</a>
 implementations. We might want to warn about what to look out for and how to
 mitigate the attacks.
       </p>
+
+      <section class="informative">
+        <h3>Security Properties of Ed25519 Implementations</h3>
+        <p>There has 
+been wide adoption of Ed25519 signatures (EdDSA algorithm with edwards25519 
+curve) due to the compact size of the keys and signatures, and the speed at 
+which signatures can be produced and verified. Many libraries exist that can
+create and verify Ed25519 signatures. Since the publication of [[RFC8032]] 
+security properties of Ed25519 signatures have been rigorously proven 
+[[Provable_Ed25519]] and [[Taming_EdDSAs]]. However it was observed that a 
+significant number of libraries do not achieve these security properties due to 
+missing input validity checks during the signature verification process. In 
+this section we summarize the security properties achievable with Ed25519 
+signatures and indicate how one can determine if a library will support those 
+properties.
+        </p>
+        <section>
+          <h4>Signature Security Properties</h4>
+          <p>Digital signatures may exhibit a number of desirable cryptographic
+properties [[Taming_EdDSAs]] among these are:
+          </p>
+          <p><strong>EUF-CMA</strong> (<em>existential unforgeability under 
+chosen message attacks</em>) is usually the minimal security property required 
+of a signature scheme. It guarantees that any efficient adversary who has the 
+public key
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>p</mi>
+            <mi>k</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math> of the signer and received an arbitrary number of signatures on
+messages of its choice (in an adaptive manner): 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo fence="false" stretchy="false">{</mo>
+            <msub>
+              <mi>m</mi>
+              <mi>i</mi>
+            </msub>
+            <mo>,</mo>
+            <msub>
+              <mi>&#x3C3;</mi>
+              <mi>i</mi>
+            </msub>
+            <msubsup>
+              <mo fence="false" stretchy="false">}</mo>
+              <mrow data-mjx-texclass="ORD">
+                <mi>i</mi>
+                <mo>=</mo>
+                <mn>1</mn>
+              </mrow>
+              <mi>N</mi>
+            </msubsup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>, 
+cannot output a valid signature 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <msup>
+              <mi>&#x3C3;</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+for a new message
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <msup>
+              <mi>m</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo>&#x2209;</mo>
+            <mo fence="false" stretchy="false">{</mo>
+            <msub>
+              <mi>m</mi>
+              <mi>i</mi>
+            </msub>
+            <msubsup>
+              <mo fence="false" stretchy="false">}</mo>
+              <mrow data-mjx-texclass="ORD">
+                <mi>i</mi>
+                <mo>=</mo>
+                <mn>1</mn>
+              </mrow>
+              <mi>N</mi>
+            </msubsup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math> 
+(except with negligible probability). In case the attacker outputs a valid 
+signature on a new message:
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <msup>
+              <mi>m</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo>,</mo>
+            <msup>
+              <mi>&#x3C3;</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo stretchy="false">)</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>,
+it is called an <em>existential 
+forgery</em>.
+          </p>
+          <p><strong>SUF-CMA</strong> (<em>strong unforgeability under chosen 
+message attacks</em>) is a stronger notion than <em>EUF-CMA</em>. It guarantees
+that for any efficient adversary who has the public key 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>p</mi>
+            <mi>k</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+of the signer and 
+received an arbitrary number of signatures on messages of its choice: 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo fence="false" stretchy="false">{</mo>
+            <msub>
+              <mi>m</mi>
+              <mi>i</mi>
+            </msub>
+            <mo>,</mo>
+            <msub>
+              <mi>&#x3C3;</mi>
+              <mi>i</mi>
+            </msub>
+            <msubsup>
+              <mo fence="false" stretchy="false">}</mo>
+              <mrow data-mjx-texclass="ORD">
+                <mi>i</mi>
+                <mo>=</mo>
+                <mn>1</mn>
+              </mrow>
+              <mi>N</mi>
+            </msubsup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>, 
+it cannot output a new valid signature pair 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <msup>
+              <mi>m</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo>,</mo>
+            <msup>
+              <mi>&#x3C3;</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo stretchy="false">)</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>, 
+such that 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <msup>
+              <mi>m</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo>,</mo>
+            <msup>
+              <mi>&#x3C3;</mi>
+              <mo>&#x2217;</mo>
+            </msup>
+            <mo stretchy="false">)</mo>
+            <mo>&#x2209;</mo>
+            <mo fence="false" stretchy="false">{</mo>
+            <msup>
+              <mi>m</mi>
+              <mi>i</mi>
+            </msup>
+            <mo>,</mo>
+            <msup>
+              <mi>&#x3C3;</mi>
+              <mi>i</mi>
+            </msup>
+            <msubsup>
+              <mo fence="false" stretchy="false">}</mo>
+              <mrow data-mjx-texclass="ORD">
+                <mi>i</mi>
+                <mo>=</mo>
+                <mn>1</mn>
+              </mrow>
+              <mi>N</mi>
+            </msubsup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+(except with negligible probability). Strong unforgeability implies that an
+adversary cannot only sign new messages, but also cannot find a new signature
+on an old message. See [[Provable_Ed25519]] for a real world attack that would 
+have been circumvented with SUF-CMA security over EUF-CMA security.
+          </p>
+          <p><strong>Binding signature</strong> (BS) We say that a signature 
+scheme is <em>binding</em> if no efficient signer can output a tuple 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">[</mo>
+            <mi>p</mi>
+            <mi>k</mi>
+            <mo>,</mo>
+            <mi>m</mi>
+            <mo>,</mo>
+            <msup>
+              <mi>m</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+            <mo>,</mo>
+            <mi>&#x3C3;</mi>
+            <mo stretchy="false">]</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>, 
+where both 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <mi>m</mi>
+            <mo>,</mo>
+            <mi>&#x3C3;</mi>
+            <mo stretchy="false">)</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+and 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <msup>
+              <mi>m</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+            <mo>,</mo>
+            <mi>&#x3C3;</mi>
+            <mo stretchy="false">)</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+are valid message signature pairs under the public key
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>p</mi>
+            <mi>k</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+and 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>m</mi>
+            <mo>&#x2260;</mo>
+            <msup>
+              <mi>m</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+(except with negligible probability). A binding signature makes it impossible
+for the signer to claim later that it has signed a different message, the 
+signature <em>binds</em> the signer to the message.
+          </p>
+          <p><strong>Strongly Binding signature</strong> (SBS) Certain 
+applications may require a signature to not only be binding to the message but 
+also be binding to the public key. We say that a signature scheme is 
+strongly-binding if any efficient signer can not output a tuple 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">[</mo>
+            <mi>p</mi>
+            <mi>k</mi>
+            <mo>,</mo>
+            <mi>m</mi>
+            <mo>,</mo>
+            <mi>p</mi>
+            <msup>
+              <mi>k</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+            <mo>,</mo>
+            <msup>
+              <mi>m</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+            <mo>,</mo>
+            <mi>&#x3C3;</mi>
+            <mo stretchy="false">]</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>, 
+where 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <mi>m</mi>
+            <mo>,</mo>
+            <mi>&#x3C3;</mi>
+            <mo stretchy="false">)</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>
+is a valid signature for the public key 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>p</mi>
+            <mi>k</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math> 
+and 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mo stretchy="false">(</mo>
+            <msup>
+              <mi>m</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+            <mo>,</mo>
+            <mi>&#x3C3;</mi>
+            <mo stretchy="false">)</mo>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math> 
+is a valid signature for the public key 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>p</mi>
+            <msup>
+              <mi>k</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math> 
+and either 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <msup>
+              <mi>m</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+            <mo>&#x2260;</mo>
+            <mi>m</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math> 
+or 
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline">
+  <mstyle displaystyle="true" scriptlevel="0">
+    <mrow data-mjx-texclass="ORD">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true">
+        <mtr>
+          <mtd>
+            <mi>p</mi>
+            <mi>k</mi>
+            <mo>&#x2260;</mo>
+            <mi>p</mi>
+            <msup>
+              <mi>k</mi>
+              <mi data-mjx-alternate="1">&#x2032;</mi>
+            </msup>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mrow>
+  </mstyle>
+</math>, 
+or both (except with negligible probability). See [[Provable_Ed25519]] for real
+world attacks that would have been circumvented with the SBS property.
+          </p>
+          <p>Note that the <em>BS</em> and <em>SBS</em> properties are forms of
+<em>non-repudiation</em>.
+          </p>
+        </section>
+        <section>
+          <h4>Achieving Ed25519 Security Properties</h4>
+          <p>As pointed on in [[Taming_EdDSAs]] flaws in Ed25519 libraries 
+primarily occur on the signature verification side where sometimes edge cases 
+are not properly checked. An Ed25519 signature library that is in conformance 
+with [[RFC8032]] or [[FIPS-186-5]], i.e., one that performs <strong>all
+</strong> specified validation checks, will have the <strong>SUF-CMA</strong> 
+property in addition to <strong>EUF-CMA</strong>.
+          </p>
+          <p>Reference [[Taming_EdDSAs]] achieves the <strong>BS</strong> and 
+<strong>SBS</strong> properties along with <strong>SUF-CMA</strong> in their 
+&quot;signature verification algorithm 2&quot; where an additional check is 
+performed against the public key <em>A</em> to make sure that it is not one of 
+eight &quot;small order points&quot;. These additional checks incur minimal processing overhead.
+          </p>
+          <p>Reference [[Taming_EdDSAs]] included a set of twelve test vectors 
+to test various Ed25519 libraries available at the time of publication. They 
+found that a significant portion missed edge cases and hence did not achieve 
+<strong>SUF-CMA</strong> (just EUF-CMA) and only two libraries out of sixteen 
+achieved all the security properties. Since the time of publication more 
+Ed25519 libraries have been created and some of the libraries have been updated
+to include all verification checks. Implementers are recommended to test the 
+Ed25519 library they are using against the test vectors of [[Taming_EdDSAs]].
+          </p>
+        </section>
+      </section>
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -755,9 +755,9 @@ security properties of Ed25519 signatures have been rigorously proven (see
 [[Provable_Ed25519]] and [[Taming_EdDSAs]]). However, it has been observed that a
 significant number of libraries do not achieve these security levels, due to 
 missing input validity checks during the signature verification process. In 
-this section we summarize the security properties achievable with Ed25519 
-signatures and indicate how one can determine if a library will support those 
-properties.
+this section, we summarize the security levels achievable with Ed25519 
+signatures, and indicate how one can determine whether a library will support those 
+levels.
         </p>
         <section>
           <h4>Signature Security Properties</h4>

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@ mitigate the attacks.
         been widely adopted, due both to the compact size of the keys and
         signatures and to the speed at 
 which signatures can be produced and verified. Many libraries exist that can
-create and verify Ed25519 signatures. Since the publication of [[RFC8032]] 
+create and verify Ed25519 signatures. Since the publication of [[RFC8032]],
 security properties of Ed25519 signatures have been rigorously proven 
 [[Provable_Ed25519]] and [[Taming_EdDSAs]]. However it was observed that a 
 significant number of libraries do not achieve these security properties due to 


### PR DESCRIPTION
Based on discussions concerning issue https://github.com/w3c/vc-di-eddsa/issues/45 I have come up with some *informative* text for the `security considerations` section. This text explains the relatively recent work that defines and proves security properties for Ed25519 signatures, how to achieve the highest levels of security, and cautions on Ed25519 library implementations.

Note that I didn't see an "easy way" to include mathematical notation with ReSpec so used MathML (a W3C specification) which is somewhat verbose and not hand editable. Some online math editors such as [LaTex Editor](https://latexeditor.lagrida.com/) can produce MathML output if you want to edit any of the equations.

Cheers Greg


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/47.html" title="Last updated on Jun 1, 2023, 6:24 PM UTC (ea626af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/47/8031fd9...Wind4Greg:ea626af.html" title="Last updated on Jun 1, 2023, 6:24 PM UTC (ea626af)">Diff</a>