### PR TITLE
Add Greg and Sebastian as Editors to EdDSA Cryptosuites

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# they will be requested for review when someone opens a 
+# they will be requested for review when someone opens a
 # pull request.
-*       @msporny @dmitrizagidulin
+*       @msporny @dmitrizagidulin @Wind4Greg @seabass-labrax
 
 # See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax

--- a/index.html
+++ b/index.html
@@ -56,10 +56,10 @@
           w3cid: 86708
         }, {
           name: "Greg Bernstein", url: "https://www.grotto-networking.com/",
-          company: "Invited Expert", w3cid: 0
+          company: "Invited Expert", w3cid: 140479
         }, {
           name: "Sebastian Crane", url: "https://github.com/seabass-labrax",
-          company: "Invited Expert", w3cid: 0
+          company: "Invited Expert", w3cid: 140132
         }],
 
         authors: [{

--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@
           company: "MIT Digital Credentials Consortium",
           companyURL: "https://digitalcredentials.mit.edu/",
           w3cid: 86708
+        }, {
+          name: "Greg Bernstein", url: "https://www.grotto-networking.com/",
+          company: "Invited Expert", w3cid: 0
+        }, {
+          name: "Sebastian Crane", url: "https://github.com/seabass-labrax",
+          company: "Invited Expert", w3cid: 0
         }],
 
         authors: [{


### PR DESCRIPTION
This PR adds Greg and Sebastian as Editors to the EdDSA Cryptosuites. The PR shouldn't be processed until after Sebastian's IE application has been processed. /cc @Wind4Greg @seabass-labrax


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/pull/50.html" title="Last updated on Jul 13, 2023, 9:53 PM UTC (ecfae04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/50/61d9296...ecfae04.html" title="Last updated on Jul 13, 2023, 9:53 PM UTC (ecfae04)">Diff</a>