### PR TITLE
Update Cryptosuite Names.

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@ containing a `type` property with the value set to
 The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
-The `cryptosuite` property of the proof MUST be `eddsa-2022`.
+The `cryptosuite` property of the proof MUST be `eddsa-rdfc-2022` or `eddsa-jcs-2022`.
           </p>
           <p>
 The `created` property of the proof MUST be an [[XMLSCHEMA11-2]]
@@ -391,10 +391,10 @@ that utilize the twisted Edwards Curve Digital Signature Algorithm.
       </p>
 
       <section>
-        <h3>eddsa-2022</h3>
+        <h3>eddsa-rdfc-2022</h3>
 
         <p>
-The `eddsa-2022` cryptographic suite takes an input document, canonicalizes
+The `eddsa-rdfc-2022` cryptographic suite takes an input document, canonicalizes
 the document using the Universal RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]], and then cryptographically hashes and signs the output
 resulting in the production of a data integrity proof. The algorithms in this
@@ -402,7 +402,7 @@ section also include the verification of such a data integrity proof.
         </p>
 
         <section>
-          <h4>Add Proof (eddsa-2022)</h4>
+          <h4>Add Proof (eddsa-rdfc-2022)</h4>
 
           <p>
 To generate a proof, the algorithm in
@@ -412,18 +412,18 @@ Section 4.1: Add Proof</a> in the Data Integrity
 For that algorithm, the cryptographic suite specific
 <a data-cite="vc-data-integrity#dfn-transformation-algorithm">
 transformation algorithm</a> is defined in Section
-<a href="#transformation-eddsa-2022"></a>, the
+<a href="#transformation-eddsa-rdfc-2022"></a>, the
 <a data-cite="vc-data-integrity#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-eddsa-2022"></a>,
+hashing algorithm</a> is defined in Section <a href="#hashing-eddsa-rdfc-2022"></a>,
 and the
 <a data-cite="vc-data-integrity#dfn-proof-serialization-algorithm">
 proof serialization algorithm</a> is defined in Section
-<a href="#proof-serialization-eddsa-2022"></a>.
+<a href="#proof-serialization-eddsa-rdfc-2022"></a>.
           </p>
         </section>
 
         <section>
-          <h4>Verify Proof (eddsa-2022)</h4>
+          <h4>Verify Proof (eddsa-rdfc-2022)</h4>
 
           <p>
 To verify a proof, the algorithm in
@@ -433,23 +433,23 @@ Section 4.2: Verify Proof</a> in the Data Integrity
 For that algorithm, the cryptographic suite specific
 <a data-cite="vc-data-integrity#dfn-transformation-algorithm">
 transformation algorithm</a> is defined in Section
-<a href="#transformation-eddsa-2022"></a>, the
+<a href="#transformation-eddsa-rdfc-2022"></a>, the
 <a data-cite="vc-data-integrity#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-eddsa-2022"></a>,
+hashing algorithm</a> is defined in Section <a href="#hashing-eddsa-rdfc-2022"></a>,
 and the
 <a data-cite="vc-data-integrity#dfn-proof-serialization-algorithm">
 proof verification algorithm</a> is defined in Section
-<a href="#proof-verification-eddsa-2022"></a>.
+<a href="#proof-verification-eddsa-rdfc-2022"></a>.
           </p>
         </section>
 
         <section>
-          <h4>Transformation (eddsa-2022)</h4>
+          <h4>Transformation (eddsa-rdfc-2022)</h4>
 
           <p>
 The following algorithm specifies how to transform an unsecured input document
 into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section <a href="#hashing-eddsa-2022"></a>.
+hashing algorithm in Section <a href="#hashing-eddsa-rdfc-2022"></a>.
           </p>
 
           <p>
@@ -469,7 +469,7 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `eddsa-rdfc-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>
@@ -484,14 +484,14 @@ Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
         </section>
 
         <section>
-          <h4>Hashing (eddsa-2022)</h4>
+          <h4>Hashing (eddsa-rdfc-2022)</h4>
 
           <p>
 The following algorithm specifies how to cryptographically hash a
 <em>transformed data document</em> and <em>proof configuration</em>
 into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section <a href="#proof-serialization-eddsa-2022"></a> or
-Section <a href="#proof-verification-eddsa-2022"></a>.
+algorithms in Section <a href="#proof-serialization-eddsa-rdfc-2022"></a> or
+Section <a href="#proof-verification-eddsa-rdfc-2022"></a>.
           </p>
 
           <p>
@@ -526,12 +526,12 @@ Return <var>hashData</var> as the <em>hash data</em>.
         </section>
 
         <section>
-          <h4>Proof Configuration (eddsa-2022)</h4>
+          <h4>Proof Configuration (eddsa-rdfc-2022)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-eddsa-2022">proof hashing algorithm</a>.
+that is used as input to the <a href="#hashing-eddsa-rdfc-2022">proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -558,7 +558,7 @@ If <var>options</var>.<var>cryptosuite</var> is set, set
             </li>
             <li>
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
-<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-2022`, an
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-rdfc-2022`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
@@ -591,7 +591,7 @@ Return <var>canonicalProofConfig</var>.
         </section>
 
         <section>
-          <h4>Proof Serialization (eddsa-2022)</h4>
+          <h4>Proof Serialization (eddsa-rdfc-2022)</h4>
 
           <p>
 The following algorithm specifies how to serialize a digital signature from
@@ -633,7 +633,7 @@ Return <var>proofBytes</var> as the <em>digital proof</em>.
         </section>
 
         <section>
-          <h4>Proof Verification (eddsa-2022)</h4>
+          <h4>Proof Verification (eddsa-rdfc-2022)</h4>
 
           <p>
 The following algorithm specifies how to verify a digital signature from
@@ -674,33 +674,19 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
       </section>
 
       <section>
-        <h3>jcs-eddsa-2022</h3>
-
-          <p class="issue" title="Cryptosuite naming convention is disputed">
-The naming convention utilized by this cryptosuite is disputed. An alternative
-of `json-eddsa-2022` was originally suggested for this cryptography suite to
-convey that it is a cryptography suite for securing JSON data utilizing the
-Twisted Edwards Curve Digital Signature Algorithm. The counter-argument to
-the original proposal was that expressing the canonicalization mechanism in
-the cryptosuite string clearly conveys to a developer that the thing that
-differentiates this cryptosuite from the `eddsa-2022` one is the use of
-JSON Canonicalization Scheme [[RFC8785]]. Other options include
-`"cryptosuite": "json-sign-2022"`, and `"cryptosuite": "json-2022"`. This
-topic is <a href="https://github.com/w3c/vc-data-integrity/issues/38">
-currently being debated in the Data Integrity work item.</a>.
-          </p>
+        <h3>eddsa-jcs-2022</h3>
 
           <p>
-The `jcs-eddsa-2022` cryptographic suite takes an input document, canonicalizes
+The `eddsa-jcs-2022` cryptographic suite takes an input document, canonicalizes
 the document using the JSON Canonicalization Scheme [[RFC8785]], and then
 cryptographically hashes and signs the output resulting in the production of a
 data integrity proof. The algorithms for this cryptographic suite are the
-same as the ones in Section <a href="#eddsa-2022"></a> except for the following
+same as the ones in Section <a href="#eddsa-rdfc-2022"></a> except for the following
 modifications:
           </p>
 
           <p>
-In Section <a href="#transformation-eddsa-2022"></a>, step <strong>1)</strong>
+In Section <a href="#transformation-eddsa-rdfc-2022"></a>, step <strong>1)</strong>
 and step <strong>2)</strong> are replaced by the following text:
           </p>
 
@@ -708,7 +694,7 @@ and step <strong>2)</strong> are replaced by the following text:
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `jcs-eddsa-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>
@@ -718,14 +704,14 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
           </ol>
 
           <p>
-In Section <a href="#proof-configuration-eddsa-2022"></a>, step <strong>8)</strong> is not performed, and steps
+In Section <a href="#proof-configuration-eddsa-rdfc-2022"></a>, step <strong>8)</strong> is not performed, and steps
 <strong>4)</strong> and <strong>9)</strong> are replaced by the following text:
           </p>
 
           <p style="padding-left: 2em;">
 <strong>4)</strong> If <var>options</var>.<var>type</var> is not set to
 `DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `jcs-eddsa-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+set to `eddsa-jcs-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
           </p>
           <p style="padding-left: 2em;">
 <strong>9)</strong> Let <var>canonicalProofConfig</var> be the result of applying the
@@ -1336,7 +1322,7 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
       <p>
         `Ed25519Signature2020` is an earlier version of a cryptographic suite
         for the usage of the EdDSA algorithm and Curve25519. While it has
-        been used in production systems, new implementations should use <a href="#eddsa-2022">`edssa-2022`</a>
+        been used in production systems, new implementations should use <a href="#eddsa-rdfc-2022">`edssa-2022`</a>
         instead. It has been kept in this specification to provide a stable reference.
       </p>
 
@@ -1770,7 +1756,7 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
     <section class="appendix informative">
       <h2>Test Vectors</h2>
       <section>
-        <h3>Representation: eddsa-2022</h3>
+        <h3>Representation: eddsa-rdfc-2022</h3>
         <p>
 The signer needs to generate a private/public key pair with the private key used
 for signing and the public key made available for verification. The
@@ -1843,7 +1829,7 @@ option document.
         data-include="TestVectors/eddsa-2022/signedDataInt.json" data-include-format="text"></pre>
       </section>
       <section>
-        <h3>Representation: jcs-eddsa-2022</h3>
+        <h3>Representation: eddsa-jcs-2022</h3>
         <p>
 The signer needs to generate a private/public key pair with the private key used
 for signing and the public key made available for verification. The


### PR DESCRIPTION
This PR updates the `DataIntegrityProof` *cryptosuite* attribute name in accordance to the recommendations in the [VC Data Integrity Specification](https://w3c.github.io/vc-data-integrity/#conventions-for-naming-cryptography-suites).

It also removes the embedded *issue* concerning "cryptosuite naming" as this has be resolved via the Data Integrity Specification and these changes.

This PR does not update the contents of Example 3 or of the *DataIntegrityProof* based test vectors. As these need to be regenerated with the new names. PRs will be filed to update these after this PR is accepted.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/53.html" title="Last updated on Aug 3, 2023, 5:46 PM UTC (ee5540e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/53/792a747...Wind4Greg:ee5540e.html" title="Last updated on Aug 3, 2023, 5:46 PM UTC (ee5540e)">Diff</a>