### PR TITLE
Simplify language that warns of invalid examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,13 +219,12 @@ as software and/or hardware that generates or consumes a
 <a>conforming proof</a>. Conforming processors MUST produce errors when
 non-conforming documents are consumed.
         </p>
-        <p>
-This document also contains examples that contain JSON and JSON-LD content. Some
-of these examples contain characters that are invalid JSON, such as inline
-comments (`//`) and the use of ellipsis (`...`) to denote
-information that adds little value to the example. Implementers are cautioned to
-remove this content if they desire to use the information as valid JSON or
-JSON-LD.
+	<p>
+This document contains examples of JSON and JSON-LD data. Some of these examples
+are invalid JSON, as they include features such as inline comments (`//`)
+explaining certain portions and ellipses (`...`) indicating the omission of
+information that is irrelevant to the example. These parts would have to be
+removed in order to treat the examples as valid JSON or JSON-LD.
         </p>
       </section>
 


### PR DESCRIPTION
This commit contains a minor improvement to a paragraph early in the specification. See also <https://github.com/w3c/vc-di-ecdsa/pull/31>.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/seabass-labrax/vc-di-eddsa/pull/59.html" title="Last updated on Aug 18, 2023, 6:51 PM UTC (76931f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/59/792a747...seabass-labrax:76931f7.html" title="Last updated on Aug 18, 2023, 6:51 PM UTC (76931f7)">Diff</a>