### PR TITLE
Add advisements to read Data Integrity considerations sections.

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,6 +728,14 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
 
     <section>
       <h2>Security Considerations</h2>
+
+      <p class="advisement">
+Before reading this section, readers are urged to familiarize themselves
+with general security advice provided in the
+<a href="https://www.w3.org/TR/vc-data-integrity/#security-considerations">
+Security Considerations section of the Data Integrity specification</a>.
+      </p>
+
       <p>
 The following section describes security considerations that developers
 implementing this specification should be aware of in order to create secure
@@ -1302,6 +1310,14 @@ Ed25519 library they are using against the test vectors of [[Taming_EdDSAs]].
 
     <section>
       <h2>Privacy Considerations</h2>
+
+      <p class="advisement">
+Before reading this section, readers are urged to familiarize themselves
+with general privacy advice provided in the
+<a href="https://www.w3.org/TR/vc-data-integrity/#privacy-considerations">
+Privacy Considerations section of the Data Integrity specification</a>.
+      </p>
+
       <p>
 The following section describes privacy considerations that developers
 implementing this specification should be aware of in order to avoid violating


### PR DESCRIPTION
This PR attempts to address issue #57 by referring the reader back to the Data Integrity Security and Privacy Considerations sections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/pull/60.html" title="Last updated on Aug 26, 2023, 10:44 PM UTC (61d6d35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/60/19f46c3...61d6d35.html" title="Last updated on Aug 26, 2023, 10:44 PM UTC (61d6d35)">Diff</a>