### PR TITLE
Proof Set and Chain Test Vectors

### DIFF
--- a/TestVectors/proof-set-chain/multiKeyPairs.json
+++ b/TestVectors/proof-set-chain/multiKeyPairs.json
@@ -1,0 +1,18 @@
+{
+  "keyPair1": {
+    "publicKeyMultibase": "z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+    "privateKeyMultibase": "z3u2W4YnTstS1nSSBAgZcYSJF43JuZ9uLV6bF38B1Bf8NugW"
+  },
+  "keyPair2": {
+    "publicKeyMultibase": "z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+    "privateKeyMultibase": "z3u2cfp4Q17kMGhNCh348a3yw3cUBiWK6RXRzyJE54sixMFn"
+  },
+  "keyPair3": {
+    "publicKeyMultibase": "z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+    "privateKeyMultibase": "z3u2Zr3tcDLBDQKGxVa9SRDFNLqNqPWsa8p9rWPvCEH6bADB"
+  },
+  "keyPair4": {
+    "publicKeyMultibase": "z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT",
+    "privateKeyMultibase": "z3u2ZTWiFwM17veUR7sXniY66Gf14SqMdpMLy7SW9x4EDdmw"
+  }
+}

--- a/TestVectors/proof-set-chain/proofChainConfig1.json
+++ b/TestVectors/proof-set-chain/proofChainConfig1.json
@@ -1,0 +1,12 @@
+{
+  "type": "DataIntegrityProof",
+  "id": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-26T22:06:38Z",
+  "verificationMethod": "https://vc.example/issuers/56783#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+  "proofPurpose": "assertionMethod",
+  "previousProof": [
+    "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+    "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54"
+  ]
+}

--- a/TestVectors/proof-set-chain/proofChainConfig2.json
+++ b/TestVectors/proof-set-chain/proofChainConfig2.json
@@ -1,0 +1,8 @@
+{
+  "type": "DataIntegrityProof",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-26T22:16:38Z",
+  "verificationMethod": "https://vc.example/issuers/56784#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+  "proofPurpose": "assertionMethod",
+  "previousProof": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23"
+}

--- a/TestVectors/proof-set-chain/proofChainConfigSigned1.json
+++ b/TestVectors/proof-set-chain/proofChainConfigSigned1.json
@@ -1,0 +1,13 @@
+{
+  "type": "DataIntegrityProof",
+  "id": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-26T22:06:38Z",
+  "verificationMethod": "https://vc.example/issuers/56783#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+  "proofPurpose": "assertionMethod",
+  "previousProof": [
+    "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+    "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54"
+  ],
+  "proofValue": "z2hcFbMaj3BJufikuLZQ36gAXVT9J3ZiwB9rqN3j7VdqyT1GaQPbMTaF1Q2gn7h75ZcJ6JpV9pvNoDumvcjtmSRAV"
+}

--- a/TestVectors/proof-set-chain/proofChainConfigSigned2.json
+++ b/TestVectors/proof-set-chain/proofChainConfigSigned2.json
@@ -1,0 +1,9 @@
+{
+  "type": "DataIntegrityProof",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-26T22:16:38Z",
+  "verificationMethod": "https://vc.example/issuers/56784#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+  "proofPurpose": "assertionMethod",
+  "previousProof": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+  "proofValue": "z6f4Lx4xiwWq8sucv6pg2vVvD5R4bxr58q2TagpwDXCxPVVS28S1iFwhor4ikhG6u4RKrNx7uSkYrCHdiiw5Js3d"
+}

--- a/TestVectors/proof-set-chain/proofChainTempDoc1.json
+++ b/TestVectors/proof-set-chain/proofChainTempDoc1.json
@@ -1,0 +1,39 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+  "type": [
+    "VerifiableCredential",
+    "AlumniCredential"
+  ],
+  "name": "Alumni Credential",
+  "description": "A minimum viable example of an Alumni Credential.",
+  "issuer": "https://vc.example/issuers/5678",
+  "validFrom": "2023-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:abcdefgh",
+    "alumniOf": "The School of Examples"
+  },
+  "proof": [
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KTX5yikM4eUukZW9qh66LGT3KZEUCACGpWcT2t4Yd54NMoFRchGmH4778omyNFAD3weSt6sNk5fuaMQmhhzNmEC"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56782#z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KXNyXDcm822dHS37tmS6Xc7FFNo8c73AfeqmfHoywPxnXWNjWKYK3VQzt3CMUoK9uAqsboVHKJXxuYwbdnfxZeA"
+    }
+  ]
+}

--- a/TestVectors/proof-set-chain/proofChainTempDoc2.json
+++ b/TestVectors/proof-set-chain/proofChainTempDoc2.json
@@ -1,0 +1,34 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+  "type": [
+    "VerifiableCredential",
+    "AlumniCredential"
+  ],
+  "name": "Alumni Credential",
+  "description": "A minimum viable example of an Alumni Credential.",
+  "issuer": "https://vc.example/issuers/5678",
+  "validFrom": "2023-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:abcdefgh",
+    "alumniOf": "The School of Examples"
+  },
+  "proof": [
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-26T22:06:38Z",
+      "verificationMethod": "https://vc.example/issuers/56783#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+      "proofPurpose": "assertionMethod",
+      "previousProof": [
+        "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+        "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54"
+      ],
+      "proofValue": "z2hcFbMaj3BJufikuLZQ36gAXVT9J3ZiwB9rqN3j7VdqyT1GaQPbMTaF1Q2gn7h75ZcJ6JpV9pvNoDumvcjtmSRAV"
+    }
+  ]
+}

--- a/TestVectors/proof-set-chain/proofSetConfig1.json
+++ b/TestVectors/proof-set-chain/proofSetConfig1.json
@@ -1,0 +1,8 @@
+{
+  "type": "DataIntegrityProof",
+  "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-24T23:36:38Z",
+  "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+  "proofPurpose": "assertionMethod"
+}

--- a/TestVectors/proof-set-chain/proofSetConfig2.json
+++ b/TestVectors/proof-set-chain/proofSetConfig2.json
@@ -1,0 +1,8 @@
+{
+  "type": "DataIntegrityProof",
+  "id": "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-24T23:36:38Z",
+  "verificationMethod": "https://vc.example/issuers/56782#z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+  "proofPurpose": "assertionMethod"
+}

--- a/TestVectors/proof-set-chain/proofSetConfigSigned1.json
+++ b/TestVectors/proof-set-chain/proofSetConfigSigned1.json
@@ -1,0 +1,9 @@
+{
+  "type": "DataIntegrityProof",
+  "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-24T23:36:38Z",
+  "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+  "proofPurpose": "assertionMethod",
+  "proofValue": "z5KTX5yikM4eUukZW9qh66LGT3KZEUCACGpWcT2t4Yd54NMoFRchGmH4778omyNFAD3weSt6sNk5fuaMQmhhzNmEC"
+}

--- a/TestVectors/proof-set-chain/proofSetConfigSigned2.json
+++ b/TestVectors/proof-set-chain/proofSetConfigSigned2.json
@@ -1,0 +1,9 @@
+{
+  "type": "DataIntegrityProof",
+  "id": "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54",
+  "cryptosuite": "eddsa-rdfc-2022",
+  "created": "2023-02-24T23:36:38Z",
+  "verificationMethod": "https://vc.example/issuers/56782#z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+  "proofPurpose": "assertionMethod",
+  "proofValue": "z5KXNyXDcm822dHS37tmS6Xc7FFNo8c73AfeqmfHoywPxnXWNjWKYK3VQzt3CMUoK9uAqsboVHKJXxuYwbdnfxZeA"
+}

--- a/TestVectors/proof-set-chain/signedProofChain1.json
+++ b/TestVectors/proof-set-chain/signedProofChain1.json
@@ -1,0 +1,52 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+  "type": [
+    "VerifiableCredential",
+    "AlumniCredential"
+  ],
+  "name": "Alumni Credential",
+  "description": "A minimum viable example of an Alumni Credential.",
+  "issuer": "https://vc.example/issuers/5678",
+  "validFrom": "2023-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:abcdefgh",
+    "alumniOf": "The School of Examples"
+  },
+  "proof": [
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KTX5yikM4eUukZW9qh66LGT3KZEUCACGpWcT2t4Yd54NMoFRchGmH4778omyNFAD3weSt6sNk5fuaMQmhhzNmEC"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56782#z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KXNyXDcm822dHS37tmS6Xc7FFNo8c73AfeqmfHoywPxnXWNjWKYK3VQzt3CMUoK9uAqsboVHKJXxuYwbdnfxZeA"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-26T22:06:38Z",
+      "verificationMethod": "https://vc.example/issuers/56783#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+      "proofPurpose": "assertionMethod",
+      "previousProof": [
+        "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+        "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54"
+      ],
+      "proofValue": "z2hcFbMaj3BJufikuLZQ36gAXVT9J3ZiwB9rqN3j7VdqyT1GaQPbMTaF1Q2gn7h75ZcJ6JpV9pvNoDumvcjtmSRAV"
+    }
+  ]
+}

--- a/TestVectors/proof-set-chain/signedProofChain2.json
+++ b/TestVectors/proof-set-chain/signedProofChain2.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+  "type": [
+    "VerifiableCredential",
+    "AlumniCredential"
+  ],
+  "name": "Alumni Credential",
+  "description": "A minimum viable example of an Alumni Credential.",
+  "issuer": "https://vc.example/issuers/5678",
+  "validFrom": "2023-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:abcdefgh",
+    "alumniOf": "The School of Examples"
+  },
+  "proof": [
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KTX5yikM4eUukZW9qh66LGT3KZEUCACGpWcT2t4Yd54NMoFRchGmH4778omyNFAD3weSt6sNk5fuaMQmhhzNmEC"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56782#z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KXNyXDcm822dHS37tmS6Xc7FFNo8c73AfeqmfHoywPxnXWNjWKYK3VQzt3CMUoK9uAqsboVHKJXxuYwbdnfxZeA"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-26T22:06:38Z",
+      "verificationMethod": "https://vc.example/issuers/56783#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+      "proofPurpose": "assertionMethod",
+      "previousProof": [
+        "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+        "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54"
+      ],
+      "proofValue": "z2hcFbMaj3BJufikuLZQ36gAXVT9J3ZiwB9rqN3j7VdqyT1GaQPbMTaF1Q2gn7h75ZcJ6JpV9pvNoDumvcjtmSRAV"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-26T22:16:38Z",
+      "verificationMethod": "https://vc.example/issuers/56784#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+      "proofPurpose": "assertionMethod",
+      "previousProof": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
+      "proofValue": "z6f4Lx4xiwWq8sucv6pg2vVvD5R4bxr58q2TagpwDXCxPVVS28S1iFwhor4ikhG6u4RKrNx7uSkYrCHdiiw5Js3d"
+    }
+  ]
+}

--- a/TestVectors/proof-set-chain/signedProofSet1.json
+++ b/TestVectors/proof-set-chain/signedProofSet1.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+  "type": [
+    "VerifiableCredential",
+    "AlumniCredential"
+  ],
+  "name": "Alumni Credential",
+  "description": "A minimum viable example of an Alumni Credential.",
+  "issuer": "https://vc.example/issuers/5678",
+  "validFrom": "2023-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:abcdefgh",
+    "alumniOf": "The School of Examples"
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+    "cryptosuite": "eddsa-rdfc-2022",
+    "created": "2023-02-24T23:36:38Z",
+    "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5KTX5yikM4eUukZW9qh66LGT3KZEUCACGpWcT2t4Yd54NMoFRchGmH4778omyNFAD3weSt6sNk5fuaMQmhhzNmEC"
+  }
+}

--- a/TestVectors/proof-set-chain/signedProofSet2.json
+++ b/TestVectors/proof-set-chain/signedProofSet2.json
@@ -1,0 +1,39 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+  "type": [
+    "VerifiableCredential",
+    "AlumniCredential"
+  ],
+  "name": "Alumni Credential",
+  "description": "A minimum viable example of an Alumni Credential.",
+  "issuer": "https://vc.example/issuers/5678",
+  "validFrom": "2023-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:abcdefgh",
+    "alumniOf": "The School of Examples"
+  },
+  "proof": [
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56781#z6MktgKTsu1QhX6QPbyqG6geXdw6FQCZBPq7uQpieWbiQiG7",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KTX5yikM4eUukZW9qh66LGT3KZEUCACGpWcT2t4Yd54NMoFRchGmH4778omyNFAD3weSt6sNk5fuaMQmhhzNmEC"
+    },
+    {
+      "type": "DataIntegrityProof",
+      "id": "urn:uuid:8cc9022b-6b14-4cf3-8571-74972c5feb54",
+      "cryptosuite": "eddsa-rdfc-2022",
+      "created": "2023-02-24T23:36:38Z",
+      "verificationMethod": "https://vc.example/issuers/56782#z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5KXNyXDcm822dHS37tmS6Xc7FFNo8c73AfeqmfHoywPxnXWNjWKYK3VQzt3CMUoK9uAqsboVHKJXxuYwbdnfxZeA"
+    }
+  ]
+}

--- a/TestVectors/proof-set-chain/unsigned.json
+++ b/TestVectors/proof-set-chain/unsigned.json
@@ -1,0 +1,16 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://www.w3.org/ns/credentials/examples/v2"
+    ],
+    "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+    "type": ["VerifiableCredential", "AlumniCredential"],
+    "name": "Alumni Credential",
+    "description": "A minimum viable example of an Alumni Credential.",
+    "issuer": "https://vc.example/issuers/5678",
+    "validFrom": "2023-01-01T00:00:00Z",
+    "credentialSubject": {
+        "id": "did:example:abcdefgh",
+        "alumniOf": "The School of Examples"
+    }
+}

--- a/index.html
+++ b/index.html
@@ -2042,7 +2042,7 @@ contains a proof signed with `keyPair1`.
 The `options` input to <a data-cite="vc-data-integrity#add-proof-set/chain">
 Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
 is shown below. Note that it does not include a `previousProof` attribute since
-we are constructing a proof set and not a chain. In addition we will be using
+we are constructing a proof set and not a chain. In addition, we will be using
 `keyPair2` for signing.
           </p>
           <pre class="example nohighlight" title="Proof Options for Set" data-include="TestVectors/proof-set-chain/proofSetConfig2.json"

--- a/index.html
+++ b/index.html
@@ -2051,7 +2051,7 @@ we are constructing a proof set and not a chain. In addition, we will be using
 Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
 Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]],
 we create an array variable, <var>allProofs</var>, and add the proof from the
-starting document to it. Since there is no `previousProof` attribute no
+starting document to it. Since there is no `previousProof` attribute, no
 modification of `unsignedDocument` is needed prior to computing the signed proof
 in step 6 of <a data-cite="vc-data-integrity#add-proof-set/chain">
 Section 4.4: Add Proof Set/Chain</a> in

--- a/index.html
+++ b/index.html
@@ -2102,7 +2102,7 @@ produces the document shown below.
           <pre class="example nohighlight" title="Temporary Unsecured Document for Binding Previous Proofs" data-include="TestVectors/proof-set-chain/proofChainTempDoc1.json"
           data-include-format="text"></pre>
           <p>
-In step 6 we use the previous document (unsecured document with previous proofs
+In step 6, we use the previous document (unsecured document with previous proofs
 added to it) to compute the `proofValue` attribute. This gives the signed
 configuration options (proof) shown below:
           </p>

--- a/index.html
+++ b/index.html
@@ -2136,12 +2136,12 @@ constructing a proof chain, however this time it is a single value.
           data-include-format="text"></pre>
           <p>
 Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
-Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
-we create an array variable <var>allProofs</var> and add the proofs from the
-starting document to it. Since the options contains the `previousProof`
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]],
+we create an array variable, <var>allProofs</var>, and add the proofs from the
+starting document to it. Since the `options` contains the `previousProof`
 attribute, we compute the <var>matchingProofs</var> variable per step 4
 of <a data-cite="vc-data-integrity#add-proof-set/chain">Section 4.4: Add Proof
-Set/Chain</a> and we set the
+Set/Chain</a>, and we set the
 <var>unsecuredDocument.proof</var> equal to the <var>matchingProofs</var>. This
 produces the document shown below.
           </p>

--- a/index.html
+++ b/index.html
@@ -2050,7 +2050,7 @@ we are constructing a proof set and not a chain. In addition, we will be using
           <p>
 Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
 Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]],
-we create an array variable <var>allProofs</var> and add the proof from the
+we create an array variable, <var>allProofs</var>, and add the proof from the
 starting document to it. Since there is no `previousProof` attribute no
 modification of `unsignedDocument` is needed prior to computing the signed proof
 in step 6 of <a data-cite="vc-data-integrity#add-proof-set/chain">

--- a/index.html
+++ b/index.html
@@ -2049,7 +2049,7 @@ we are constructing a proof set and not a chain. In addition, we will be using
           data-include-format="text"></pre>
           <p>
 Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
-Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]],
 we create an array variable <var>allProofs</var> and add the proof from the
 starting document to it. Since there is no `previousProof` attribute no
 modification of `unsignedDocument` is needed prior to computing the signed proof

--- a/index.html
+++ b/index.html
@@ -2155,8 +2155,8 @@ configuration options (proof) shown below:
           <pre class="example nohighlight" title="Signed Configuration Options (Extended)" data-include="TestVectors/proof-set-chain/proofChainConfigSigned2.json"
           data-include-format="text"></pre>
           <p>
-The above signed proof options gets appended to the <var>allProofs</var>
-variable which then gets set as the `proof` attribute of the unsigned document
+The signed proof `options` above gets appended to the <var>allProofs</var>
+variable, which then gets set as the `proof` attribute of the unsigned document
 to produce the final signed document as shown below.
           </p>
           <pre class="example nohighlight" title="Signed Proof Chain (Extended)" data-include="TestVectors/proof-set-chain/signedProofChain2.json"

--- a/index.html
+++ b/index.html
@@ -2071,8 +2071,8 @@ to produce the final signed document as shown below.
         <section>
           <h4>Proof Chain with Multiple Dependencies</h4>
           <p>
-This collection of test vectors demonstrates construction a proof chain. We
-start with a document containing a proof set, i.e., our previous example, we
+This collection of test vectors demonstrates the construction a proof chain. We
+start with a document containing a proof set, i.e., our previous example, and
 then add a new proof to the credential that has a dependency on the existing
 proofs. This example also demonstrates the case where the `previousProofs`
 attribute is an array. This example uses `keyPair3` and the starting document is

--- a/index.html
+++ b/index.html
@@ -2016,7 +2016,7 @@ option document.
       <section>
         <h3>Proof Sets and Chains</h3>
         <p>
-Proof sets and chains are defined in the [[VC-DATA-INTEGRITY]] specification. We
+Proof sets and chains are defined in the [[VC-DATA-INTEGRITY]]. We
 provide test vectors showing the creation of proof sets and chains with the
 `eddsa-rdfc-2022` cryptosuite. Multiple signers are involved in the generation
 of proof sets and chains so multiple public/private key pairs are needed. These
@@ -2039,8 +2039,8 @@ contains a proof signed with `keyPair1`.
           <pre class="example nohighlight" title="Starting Document for Proof Set" data-include="TestVectors/proof-set-chain/signedProofSet1.json"
           data-include-format="text"></pre>
           <p>
-The `options` input to the <a data-cite="vc-data-integrity#add-proof-set/chain">
-Section 4.4: Add Proof Set/Chain</a> in the Data Integrity [[VC-DATA-INTEGRITY]]
+The `options` input to <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
 is shown below. Note that it does not include a `previousProof` attribute since
 we are constructing a proof set and not a chain. In addition we will be using
 `keyPair2` for signing.
@@ -2049,12 +2049,12 @@ we are constructing a proof set and not a chain. In addition we will be using
           data-include-format="text"></pre>
           <p>
 Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
-Section 4.4: Add Proof Set/Chain</a> in the Data Integrity [[VC-DATA-INTEGRITY]]
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
 we create an array variable <var>allProofs</var> and add the proof from the
 starting document to it. Since there is no `previousProof` attribute no
 modification of `unsignedDocument` is needed prior to computing the signed proof
 in step 6 of <a data-cite="vc-data-integrity#add-proof-set/chain">
-Section 4.4: Add Proof Set/Chain</a> in the Data Integrity
+Section 4.4: Add Proof Set/Chain</a> in
 [[VC-DATA-INTEGRITY]]. The signed proof configuration is shown below.
           </p>
           <pre class="example nohighlight" title="Signed Proof Options" data-include="TestVectors/proof-set-chain/proofSetConfigSigned2.json"
@@ -2062,13 +2062,59 @@ Section 4.4: Add Proof Set/Chain</a> in the Data Integrity
           <p>
 The above signed proof options gets appended to the <var>allProofs</var>
 variable which then gets set as the `proof` attribute of the unsigned document
-as shown below.
+to produce the final signed document as shown below.
           </p>
           <pre class="example nohighlight" title="Signed Proof Set" data-include="TestVectors/proof-set-chain/signedProofSet2.json"
           data-include-format="text"></pre>
         </section>
+
         <section>
           <h4>Proof Chain with Multiple Dependencies</h4>
+          <p>
+This collection of test vectors demonstrates construction a proof chain. We
+start with a document containing a proof set, i.e., our previous example, we
+then add a new proof to the credential that has a dependency on the existing
+proofs. This example also demonstrates the case where the `previousProofs`
+attribute is an array. This example uses `keyPair3` and the starting document is
+given below.
+          </p>
+          <pre class="example nohighlight" title="Starting Document for Proof Chain" data-include="TestVectors/proof-set-chain/signedProofSet2.json"
+          data-include-format="text"></pre>
+          <p>
+The `options` input to <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
+is shown below. Note that it includes a `previousProof` attribute since we are
+constructing a proof chain.
+          </p>
+          <pre class="example nohighlight" title="Options for Proof Chain" data-include="TestVectors/proof-set-chain/proofChainConfig1.json"
+          data-include-format="text"></pre>
+          <p>
+Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
+we create an array variable <var>allProofs</var> and add the proofs from the
+starting document to it. Since the options contains the `previousProof`
+attribute, we compute the <var>matchingProofs</var> variable per step 4
+of <a data-cite="vc-data-integrity#add-proof-set/chain">Section 4.4: Add Proof
+Set/Chain</a> and we set the
+<var>unsecuredDocument.proof</var> equal to the <var>matchingProofs</var>. This
+produces the document shown below.
+          </p>
+          <pre class="example nohighlight" title="Temporary Unsecured Document for Binding Previous Proofs" data-include="TestVectors/proof-set-chain/proofChainTempDoc1.json"
+          data-include-format="text"></pre>
+          <p>
+In step 6 we use the previous document (unsecured document with previous proofs
+added to it) to compute the `proofValue` attribute. This gives the signed
+configuration options (proof) shown below:
+          </p>
+          <pre class="example nohighlight" title="Signed Configuration Options (proof)" data-include="TestVectors/proof-set-chain/proofChainConfigSigned1.json"
+          data-include-format="text"></pre>
+          <p>
+The above signed proof options gets appended to the <var>allProofs</var>
+variable which then gets set as the `proof` attribute of the unsigned document
+to produce the final signed document as shown below.
+          </p>
+          <pre class="example nohighlight" title="Signed Proof Chain" data-include="TestVectors/proof-set-chain/signedProofChain1.json"
+          data-include-format="text"></pre>
         </section>
         <section>
           <h4>Extended Proof Chain</h4>

--- a/index.html
+++ b/index.html
@@ -2118,14 +2118,6 @@ to produce the final signed document as shown below.
         </section>
         <section>
           <h4>Extended Proof Chain</h4>
-<!-- * Starting with a document with a proof chain, add a proof to form a longer proof chain.
-  * Starting input: `signedProofChain1.json`
-  * Options: `proofChainConfig2.json`, Key Pair: keyPair4
-  * Matching set is non-empty so we "Set unsecuredDocument.proof to matchingProofs." for use
-    in AddProof steps, this document provides the "binding" of the previous proofs and is shown in
-    `proofChainTempDoc2.json`
-  * The computed proof is shown in `proofChainConfigSigned2.json`, it is appended to `allProofs`
-  and added to the unsigned to produce the final signed document `signedProofChain2.json` -->
           <p>
 This collection of test vectors demonstrates construction of an extended proof
 chain. We start with the output of the previous section and add an additional

--- a/index.html
+++ b/index.html
@@ -2032,7 +2032,7 @@ The original unsigned credential is shown below:
         <section>
           <h4>Proof Set</h4>
           <p>
-To demonstrate creating a proof set. We start with a document containing a
+To demonstrate creating a proof set, we start with a document containing a
 single proof and add another proof to it. The start document is shown below and
 contains a proof signed with `keyPair1`.
           </p>

--- a/index.html
+++ b/index.html
@@ -2118,6 +2118,57 @@ to produce the final signed document as shown below.
         </section>
         <section>
           <h4>Extended Proof Chain</h4>
+<!-- * Starting with a document with a proof chain, add a proof to form a longer proof chain.
+  * Starting input: `signedProofChain1.json`
+  * Options: `proofChainConfig2.json`, Key Pair: keyPair4
+  * Matching set is non-empty so we "Set unsecuredDocument.proof to matchingProofs." for use
+    in AddProof steps, this document provides the "binding" of the previous proofs and is shown in
+    `proofChainTempDoc2.json`
+  * The computed proof is shown in `proofChainConfigSigned2.json`, it is appended to `allProofs`
+  and added to the unsigned to produce the final signed document `signedProofChain2.json` -->
+          <p>
+This collection of test vectors demonstrates construction of an extended proof
+chain. We start with the output of the previous section and add an additional
+proof that is dependent one of the existing proofs. This example uses `keyPair4`
+and the starting document is given below.
+          </p>
+          <pre class="example nohighlight" title="Starting Document for Extended Proof Chain" data-include="TestVectors/proof-set-chain/signedProofChain1.json"
+          data-include-format="text"></pre>
+          <p>
+The `options` input to <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
+is shown below. Note that it includes a `previousProof` attribute since we are
+constructing a proof chain, however this time it is a single value.
+          </p>
+          <pre class="example nohighlight" title="Options for Extended Proof Chain" data-include="TestVectors/proof-set-chain/proofChainConfig2.json"
+          data-include-format="text"></pre>
+          <p>
+Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
+we create an array variable <var>allProofs</var> and add the proofs from the
+starting document to it. Since the options contains the `previousProof`
+attribute, we compute the <var>matchingProofs</var> variable per step 4
+of <a data-cite="vc-data-integrity#add-proof-set/chain">Section 4.4: Add Proof
+Set/Chain</a> and we set the
+<var>unsecuredDocument.proof</var> equal to the <var>matchingProofs</var>. This
+produces the document shown below.
+          </p>
+          <pre class="example nohighlight" title="Temporary Unsecured Document for Binding Previous Proofs (Extended Chain)" data-include="TestVectors/proof-set-chain/proofChainTempDoc2.json"
+            data-include-format="text"></pre>
+          <p>
+In step 6 we use the previous document (unsecured document with previous proofs
+added to it) to compute the `proofValue` attribute. This gives the signed
+configuration options (proof) shown below:
+          </p>
+          <pre class="example nohighlight" title="Signed Configuration Options (Extended)" data-include="TestVectors/proof-set-chain/proofChainConfigSigned2.json"
+          data-include-format="text"></pre>
+          <p>
+The above signed proof options gets appended to the <var>allProofs</var>
+variable which then gets set as the `proof` attribute of the unsigned document
+to produce the final signed document as shown below.
+          </p>
+          <pre class="example nohighlight" title="Signed Proof Chain (Extended)" data-include="TestVectors/proof-set-chain/signedProofChain2.json"
+          data-include-format="text"></pre>
         </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2018,7 +2018,7 @@ option document.
         <p>
 Proof sets and chains are defined in the [[VC-DATA-INTEGRITY]]. We
 provide test vectors showing the creation of proof sets and chains with the
-`eddsa-rdfc-2022` cryptosuite. Multiple signers are involved in the generation
+`eddsa-rdfc-2022` cryptosuite. Multiple signers are usually involved in the generation
 of proof sets and chains so multiple public/private key pairs are needed. These
 are shown below.
         </p>

--- a/index.html
+++ b/index.html
@@ -2060,8 +2060,8 @@ Section 4.4: Add Proof Set/Chain</a> in
           <pre class="example nohighlight" title="Signed Proof Options" data-include="TestVectors/proof-set-chain/proofSetConfigSigned2.json"
           data-include-format="text"></pre>
           <p>
-The above signed proof options gets appended to the <var>allProofs</var>
-variable which then gets set as the `proof` attribute of the unsigned document
+The signed proof `options` above gets appended to the <var>allProofs</var>
+variable, which then gets set as the `proof` attribute of the unsigned document
 to produce the final signed document as shown below.
           </p>
           <pre class="example nohighlight" title="Signed Proof Set" data-include="TestVectors/proof-set-chain/signedProofSet2.json"

--- a/index.html
+++ b/index.html
@@ -2148,7 +2148,7 @@ produces the document shown below.
           <pre class="example nohighlight" title="Temporary Unsecured Document for Binding Previous Proofs (Extended Chain)" data-include="TestVectors/proof-set-chain/proofChainTempDoc2.json"
             data-include-format="text"></pre>
           <p>
-In step 6 we use the previous document (unsecured document with previous proofs
+In step 6, we use the previous document (unsecured document with previous proofs
 added to it) to compute the `proofValue` attribute. This gives the signed
 configuration options (proof) shown below:
           </p>

--- a/index.html
+++ b/index.html
@@ -2121,8 +2121,8 @@ to produce the final signed document as shown below.
           <p>
 This collection of test vectors demonstrates construction of an extended proof
 chain. We start with the output of the previous section and add an additional
-proof that is dependent one of the existing proofs. This example uses `keyPair4`
-and the starting document is given below.
+proof that is dependent on one of the existing proofs. This example uses
+`keyPair4`, and the starting document is given below.
           </p>
           <pre class="example nohighlight" title="Starting Document for Extended Proof Chain" data-include="TestVectors/proof-set-chain/signedProofChain1.json"
           data-include-format="text"></pre>

--- a/index.html
+++ b/index.html
@@ -2018,7 +2018,7 @@ option document.
         <p>
 Proof sets and chains are defined in the [[VC-DATA-INTEGRITY]]. We
 provide test vectors showing the creation of proof sets and chains with the
-`eddsa-rdfc-2022` cryptosuite. Multiple signers are usually involved in the generation
+`eddsa-rdfc-2022` cryptosuite. Multiple signers can be involved in the generation
 of proof sets and chains so multiple public/private key pairs are needed. These
 are shown below.
         </p>

--- a/index.html
+++ b/index.html
@@ -2109,8 +2109,8 @@ configuration options (proof) shown below:
           <pre class="example nohighlight" title="Signed Configuration Options (proof)" data-include="TestVectors/proof-set-chain/proofChainConfigSigned1.json"
           data-include-format="text"></pre>
           <p>
-The above signed proof options gets appended to the <var>allProofs</var>
-variable which then gets set as the `proof` attribute of the unsigned document
+The signed proof `options` above gets appended to the <var>allProofs</var>
+variable, which then gets set as the `proof` attribute of the unsigned document
 to produce the final signed document as shown below.
           </p>
           <pre class="example nohighlight" title="Signed Proof Chain" data-include="TestVectors/proof-set-chain/signedProofChain1.json"

--- a/index.html
+++ b/index.html
@@ -2033,7 +2033,7 @@ The original unsigned credential is shown below:
           <h4>Proof Set</h4>
           <p>
 To demonstrate creating a proof set, we start with a document containing a
-single proof and add another proof to it. The start document is shown below and
+single proof and add another proof to it. The starting document is shown below and
 contains a proof signed with `keyPair1`.
           </p>
           <pre class="example nohighlight" title="Starting Document for Proof Set" data-include="TestVectors/proof-set-chain/signedProofSet1.json"

--- a/index.html
+++ b/index.html
@@ -2090,12 +2090,12 @@ constructing a proof chain.
           data-include-format="text"></pre>
           <p>
 Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
-Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]]
-we create an array variable <var>allProofs</var> and add the proofs from the
+Section 4.4: Add Proof Set/Chain</a> in [[VC-DATA-INTEGRITY]],
+we create an array variable, <var>allProofs</var>, and add the proofs from the
 starting document to it. Since the options contains the `previousProof`
 attribute, we compute the <var>matchingProofs</var> variable per step 4
 of <a data-cite="vc-data-integrity#add-proof-set/chain">Section 4.4: Add Proof
-Set/Chain</a> and we set the
+Set/Chain</a>, and we set the
 <var>unsecuredDocument.proof</var> equal to the <var>matchingProofs</var>. This
 produces the document shown below.
           </p>

--- a/index.html
+++ b/index.html
@@ -2013,6 +2013,66 @@ option document.
         <pre class="example nohighlight" title="Signed Credential"
         data-include="TestVectors/Ed25519Signature2020/signedEdSig.json" data-include-format="text"></pre>
       </section>
+      <section>
+        <h3>Proof Sets and Chains</h3>
+        <p>
+Proof sets and chains are defined in the [[VC-DATA-INTEGRITY]] specification. We
+provide test vectors showing the creation of proof sets and chains with the
+`eddsa-rdfc-2022` cryptosuite. Multiple signers are involved in the generation
+of proof sets and chains so multiple public/private key pairs are needed. These
+are shown below.
+        </p>
+        <pre class="example nohighlight" title="Public and Private Key Pairs" data-include="TestVectors/proof-set-chain/multiKeyPairs.json"
+        data-include-format="text"></pre>
+        <p>
+The original unsigned credential is shown below:
+        </p>
+        <pre class="example nohighlight" title="Unsigned Credential" data-include="TestVectors/proof-set-chain/unsigned.json"
+        data-include-format="text"></pre>
+        <section>
+          <h4>Proof Set</h4>
+          <p>
+To demonstrate creating a proof set. We start with a document containing a
+single proof and add another proof to it. The start document is shown below and
+contains a proof signed with `keyPair1`.
+          </p>
+          <pre class="example nohighlight" title="Starting Document for Proof Set" data-include="TestVectors/proof-set-chain/signedProofSet1.json"
+          data-include-format="text"></pre>
+          <p>
+The `options` input to the <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in the Data Integrity [[VC-DATA-INTEGRITY]]
+is shown below. Note that it does not include a `previousProof` attribute since
+we are constructing a proof set and not a chain. In addition we will be using
+`keyPair2` for signing.
+          </p>
+          <pre class="example nohighlight" title="Proof Options for Set" data-include="TestVectors/proof-set-chain/proofSetConfig2.json"
+          data-include-format="text"></pre>
+          <p>
+Per the algorithm of <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in the Data Integrity [[VC-DATA-INTEGRITY]]
+we create an array variable <var>allProofs</var> and add the proof from the
+starting document to it. Since there is no `previousProof` attribute no
+modification of `unsignedDocument` is needed prior to computing the signed proof
+in step 6 of <a data-cite="vc-data-integrity#add-proof-set/chain">
+Section 4.4: Add Proof Set/Chain</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]]. The signed proof configuration is shown below.
+          </p>
+          <pre class="example nohighlight" title="Signed Proof Options" data-include="TestVectors/proof-set-chain/proofSetConfigSigned2.json"
+          data-include-format="text"></pre>
+          <p>
+The above signed proof options gets appended to the <var>allProofs</var>
+variable which then gets set as the `proof` attribute of the unsigned document
+as shown below.
+          </p>
+          <pre class="example nohighlight" title="Signed Proof Set" data-include="TestVectors/proof-set-chain/signedProofSet2.json"
+          data-include-format="text"></pre>
+        </section>
+        <section>
+          <h4>Proof Chain with Multiple Dependencies</h4>
+        </section>
+        <section>
+          <h4>Extended Proof Chain</h4>
+        </section>
     </section>
 
     <section class="informative">


### PR DESCRIPTION
This PR provides test vectors (**informational**) for proof *sets* and *chains* for the `eddsa-rdfc-2022` based on the updated procedures in the VC Data Integrity specification.

* Starting with a document with a single proof add a proof to form a simple proof set.
* Starting with a document with a proof set, add a proof to form a proof chain. In this case we will also demonstrate where *previousProof* can be any array, i.e., the new proof relies on two other proofs.
* Starting with a document with a proof chain, add a proof to form a longer proof chain.

These test vectors make use of the same starting unsigned document used for all previous test vectors and adds a collection of four public/private key pairs for use in generating the test vectors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/70.html" title="Last updated on Dec 6, 2023, 8:15 PM UTC (12a2b75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/70/780395b...Wind4Greg:12a2b75.html" title="Last updated on Dec 6, 2023, 8:15 PM UTC (12a2b75)">Diff</a>