### PR TITLE
JCS Context Injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,13 +886,13 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
 Let |transformedData| be the result of running the algorithm in Section
 <a href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters where step
-<strong>1)</strong> and step <strong>2)</strong> are replaced by the following
-text respectively:
+<strong>1)</strong> and step <strong>2)</strong> are respectively replaced by
+the following texts:
                 <ol class="algorithm">
                   <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `eddsa-jcs-2022`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
                   </li>
                   <li>
@@ -965,13 +965,13 @@ the |proofOptions|.<var>@context</var>:
               <ol class="algorithm">
                 <li>
 The |securedDocument|.<var>@context</var> MUST contain all values contained in the
-|proofOptions|.<var>@context</var> in the same order. Otherwise set |verified| to
+|proofOptions|.<var>@context</var> in the same order. Otherwise, set |verified| to
 `false` and skip to the last step.
                 </li>
                 <li>
 The |securedDocument|.<var>@context</var> MUST NOT have any values preceding the
-values contained in the |proofOptions|.<var>@context</var> but those MAY be followed by
-additional values not contained in the |proof|.<var>@context</var>. Otherwise
+values contained in the |proofOptions|.<var>@context</var>, but those MAY be followed by
+additional values not contained in the |proof|.<var>@context</var>. Otherwise,
 set |verified| to `false` and skip to the last step.
                 </li>
               </ol>
@@ -985,13 +985,13 @@ Set |securedDocument|.<var>@context</var> equal to
 Let |transformedData| be the result of running the algorithm in Section
 <a href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument| and
 |proofOptions| passed as parameters where step
-<strong>1)</strong> and step <strong>2)</strong> are replaced by the following
-text respectively:
+<strong>1)</strong> and step <strong>2)</strong> are respectively replaced by
+the following texts:
                 <ol class="algorithm">
                   <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `eddsa-jcs-2022`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
                   </li>
                   <li>
@@ -1005,7 +1005,7 @@ Let |proofConfig| be the result of running the algorithm in
 Section [[[#proof-configuration-eddsa-rdfc-2022]]] with
 |unsecuredDocument| and |proofOptions| passed as a parameters and where
 steps <strong>4)</strong> and
-<strong>9)</strong> are replaced by the following text respectively:
+<strong>9)</strong> are respectively replaced by the following texts:
                 <ol class="algorithm">
                   <li>
 If <var>options</var>.<var>type</var> is not set to
@@ -1035,7 +1035,7 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
                   <dd>|verified|</dd>
                   <dt>[=verifiedDocument=]</dt>
                   <dd>
-  |unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+  |unsecuredDocument|, if |verified| is `true`; otherwise, <a data-cite="INFRA#nulls">Null</a></dd>
                 </dl>
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -866,50 +866,22 @@ Let |proof| be a clone of the proof options, |options|.
               </li>
               <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-eddsa-rdfc-2022]]] with
-|options| passed as a parameter and where
-steps <strong>4)</strong> and
-<strong>9)</strong> are replaced by the following text respectively:
-                <ol class="algorithm">
-                  <li>
-If <var>options</var>.<var>type</var> is not set to
-`DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `eddsa-jcs-2022`, an error MUST be raised and it SHOULD use error
-code `PROOF_GENERATION_ERROR`.
-                  </li>
-                  <li>
-Let <var>canonicalProofConfig</var> be the result of applying the
-JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
-                  </li>
-                </ol>
+Section [[[#proof-configuration-eddsa-jcs-2022]]] with
+|options| passed as a parameter.
               </li>
               <li>
 Let |transformedData| be the result of running the algorithm in Section
-<a href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument|,
-|proofConfig|, and |options| passed as parameters where step
-<strong>1)</strong> and step <strong>2)</strong> are respectively replaced by
-the following texts:
-                <ol class="algorithm">
-                  <li>
-If <var>options</var>.<var>type</var> is not set to the string
-`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022`, then an error MUST be raised and it SHOULD
-use error code `PROOF_GENERATION_ERROR`.
-                  </li>
-                  <li>
-Let <var>canonicalDocument</var> be the result of applying the
-JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
-                  </li>
-                </ol>
+<a href="#transformation-eddsa-jcs-2022"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
               </li>
               <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-eddsa-rdfc-2022]]] with |transformedData| and |proofConfig|
+[[[#hashing-eddsa-jcs-2022]]] with |transformedData| and |proofConfig|
 passed as a parameters.
               </li>
               <li>
 Let |proofBytes| be the result of running the algorithm in Section
-[[[#proof-serialization-eddsa-rdfc-2022]]] with |hashData| and
+[[[#proof-serialization-eddsa-jcs-2022]]] with |hashData| and
 |options| passed as parameters.
               </li>
               <li>
@@ -976,49 +948,22 @@ Set |unsecuredDocument|.<var>@context</var> equal to
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section
-<a href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument| and
-|proofOptions| passed as parameters where step
-<strong>1)</strong> and step <strong>2)</strong> are respectively replaced by
-the following texts:
-                <ol class="algorithm">
-                  <li>
-If <var>options</var>.<var>type</var> is not set to the string
-`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
-                  </li>
-                  <li>
-Let <var>canonicalDocument</var> be the result of applying the
-JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
-                  </li>
-                </ol>
+<a href="#transformation-eddsa-jcs-2022"></a> with |unsecuredDocument| and
+|proofOptions| passed as parameters.
               </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-eddsa-rdfc-2022]]] with
-|unsecuredDocument| and |proofOptions| passed as a parameters and where step
-<strong>8)</strong> is not performed and steps <strong>4)</strong> and
-<strong>9)</strong> are respectively replaced by the following texts:
-                <ol class="algorithm">
-                  <li>
-If <var>options</var>.<var>type</var> is not set to
-`DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `eddsa-jcs-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
-                  </li>
-                  <li>
-Let <var>canonicalProofConfig</var> be the result of applying the
-JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
-                  </li>
-                </ol>
-              </li>
+Section [[[#proof-configuration-eddsa-jcs-2022]]] with
+|unsecuredDocument| and |proofOptions| passed as a parameters.
+            </li>
             <li>
   Let |hashData| be the result of running the algorithm in Section
-  [[[#hashing-eddsa-rdfc-2022]]] with |transformedData| and |proofConfig|
+  [[[#hashing-eddsa-jcs-2022]]] with |transformedData| and |proofConfig|
   passed as a parameters.
             </li>
             <li>
   Let |verified:boolean| be the result of running the algorithm in Section
-  [[[#proof-verification-eddsa-rdfc-2022]]] algorithm on |hashData|,
+  [[[#proof-verification-eddsa-jcs-2022]]] algorithm on |hashData|,
   |proofBytes|, and |proofConfig|.
               </li>
               <li>
@@ -1257,7 +1202,7 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
 
         </section>
       </section>
-<!-- End of JCS section -->
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -841,45 +841,10 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
 The `eddsa-jcs-2022` cryptographic suite takes an input document, canonicalizes
 the document using the JSON Canonicalization Scheme [[RFC8785]], and then
 cryptographically hashes and signs the output resulting in the production of a
-data integrity proof. The algorithms for this cryptographic suite are the same
-as the ones in Section <a href="#eddsa-rdfc-2022"></a> except for the
-following modifications:
+data integrity proof.
           </p>
 
-          <p>
-In Section <a href="#transformation-eddsa-rdfc-2022"></a>, step
-<strong>1)</strong> and step <strong>2)</strong> are replaced by the following
-text:
-          </p>
 
-          <ol class="algorithm">
-            <li>
-If <var>options</var>.<var>type</var> is not set to the string
-`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
-            </li>
-            <li>
-Let <var>canonicalDocument</var> be the result of applying the
-JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
-            </li>
-          </ol>
-
-          <p>
-In Section <a href="#proof-configuration-eddsa-rdfc-2022"></a>, step
-<strong>8)</strong> is not performed, and steps <strong>4)</strong> and
-<strong>9)</strong> are replaced by the following text:
-          </p>
-
-          <p style="padding-left: 2em;">
-<strong>4)</strong> If <var>options</var>.<var>type</var> is not set to
-`DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `eddsa-jcs-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
-          </p>
-          <p style="padding-left: 2em;">
-<strong>9)</strong> Let <var>canonicalProofConfig</var> be the result of applying the
-JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
-          </p>
 
           <section>
             <h4>Create Proof (eddsa-jcs-2022)</h4>
@@ -892,11 +857,68 @@ options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
 is produced as output.
             </p>
 
-            <p>
-The algorithm is the same as the one described in Section
-[[[#create-proof-eddsa-rdfc-2022]]] with the changes outlined in
-Section [[[#eddsa-jcs-2022]]].
-            </p>
+            <ol class="algorithm">
+              <li>
+Let |proof| be a clone of the proof options, |options|.
+              </li>
+              <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration-eddsa-rdfc-2022]]] with
+|options| passed as a parameter and where
+steps <strong>4)</strong> and
+<strong>9)</strong> are replaced by the following text respectively:
+                <ol class="algorithm">
+                  <li>
+If <var>options</var>.<var>type</var> is not set to
+`DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
+set to `eddsa-jcs-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+                  </li>
+                  <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters where step
+<strong>1)</strong> and step <strong>2)</strong> are replaced by the following
+text respectively:
+                <ol class="algorithm">
+                  <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+                  </li>
+                  <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-eddsa-rdfc-2022]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+              </li>
+              <li>
+Let |proofBytes| be the result of running the algorithm in Section
+[[[#proof-serialization-eddsa-rdfc-2022]]] with |hashData| and
+|options| passed as parameters.
+              </li>
+              <li>
+Set |proof|.<var>@context </var>to |unsecuredDocument|.<var>@context</var>.
+              </li>
+              <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base58-btc-encoded Multibase value</a> of the |proofBytes|.
+              </li>
+              <li>
+  Return |proof| as the [=data integrity proof=].
+              </li>
+            </ol>
           </section>
 
           <section>

--- a/index.html
+++ b/index.html
@@ -961,25 +961,18 @@ Let |proofBytes| be the
 value</a> in |securedDocument|.|proof|.|proofValue|.
             </li>
             <li>
-If |proofOptions|.<var>@context</var> exists, perform the following checks  between the |securedDocument|.<var>@context</var> the |proofOptions|.<var>@context</var>:
+If |proofOptions|.<var>@context</var> exists:
               <ol class="algorithm">
                 <li>
-The |securedDocument|.<var>@context</var> MUST start with all values contained in the
-|proofOptions|.<var>@context</var> in the same order. Otherwise, set |verified| to
-`false` and skip to the last step.
+Check that the |securedDocument|.<var>@context</var> starts with all values
+contained in the |proofOptions|.<var>@context</var> in the same order.
+Otherwise, set |verified| to `false` and skip to the last step.
                 </li>
                 <li>
-The |securedDocument|.<var>@context</var> MUST NOT have any values preceding the
-values contained in the |proofOptions|.<var>@context</var>, but those MAY be followed by
-additional values not contained in the |proof|.<var>@context</var>. Otherwise,
-set |verified| to `false` and skip to the last step.
+Set |unsecuredDocument|.<var>@context</var> equal to
+|proofOptions|.<var>@context</var>.
                 </li>
               </ol>
-
-            </li>
-            <li>
-Set |securedDocument|.<var>@context</var> equal to
-|proofOptions|.<var>@context</var>.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section
@@ -1003,8 +996,8 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
             <li>
 Let |proofConfig| be the result of running the algorithm in
 Section [[[#proof-configuration-eddsa-rdfc-2022]]] with
-|unsecuredDocument| and |proofOptions| passed as a parameters and where
-steps <strong>4)</strong> and
+|unsecuredDocument| and |proofOptions| passed as a parameters and where step
+<strong>8)</strong> is not performed and steps <strong>4)</strong> and
 <strong>9)</strong> are respectively replaced by the following texts:
                 <ol class="algorithm">
                   <li>

--- a/index.html
+++ b/index.html
@@ -874,7 +874,8 @@ steps <strong>4)</strong> and
                   <li>
 If <var>options</var>.<var>type</var> is not set to
 `DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
-set to `eddsa-jcs-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+set to `eddsa-jcs-2022`, an error MUST be raised and it SHOULD use error
+code `PROOF_GENERATION_ERROR`.
                   </li>
                   <li>
 Let <var>canonicalProofConfig</var> be the result of applying the
@@ -892,8 +893,8 @@ the following texts:
                   <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
+set to the string `eddsa-jcs-2022`, then an error MUST be raised and it SHOULD
+use error code `PROOF_GENERATION_ERROR`.
                   </li>
                   <li>
 Let <var>canonicalDocument</var> be the result of applying the
@@ -960,11 +961,10 @@ Let |proofBytes| be the
 value</a> in |securedDocument|.|proof|.|proofValue|.
             </li>
             <li>
-Perform the following checks  between the |securedDocument|.<var>@context</var> and
-the |proofOptions|.<var>@context</var>:
+If |proofOptions|.<var>@context</var> exists, perform the following checks  between the |securedDocument|.<var>@context</var> the |proofOptions|.<var>@context</var>:
               <ol class="algorithm">
                 <li>
-The |securedDocument|.<var>@context</var> MUST contain all values contained in the
+The |securedDocument|.<var>@context</var> MUST start with all values contained in the
 |proofOptions|.<var>@context</var> in the same order. Otherwise, set |verified| to
 `false` and skip to the last step.
                 </li>

--- a/index.html
+++ b/index.html
@@ -880,8 +880,8 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
                 </ol>
               </li>
               <li>
-Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument|,
+Let |transformedData| be the result of running the algorithm in Section
+<a href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters where step
 <strong>1)</strong> and step <strong>2)</strong> are replaced by the following
 text respectively:
@@ -917,7 +917,7 @@ Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
 base58-btc-encoded Multibase value</a> of the |proofBytes|.
               </li>
               <li>
-  Return |proof| as the [=data integrity proof=].
+Return |proof| as the [=data integrity proof=].
               </li>
             </ol>
           </section>

--- a/index.html
+++ b/index.html
@@ -909,7 +909,8 @@ Let |proofBytes| be the result of running the algorithm in Section
 |options| passed as parameters.
               </li>
               <li>
-Set |proof|.<var>@context </var>to |unsecuredDocument|.<var>@context</var>.
+Set <var>proof</var>.<var>@context</var>to
+<var>unsecuredDocument</var>.<var>@context</var>.
               </li>
               <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">

--- a/index.html
+++ b/index.html
@@ -1114,6 +1114,67 @@ Return <var>hashData</var> as the <em>hash data</em>.
         </section>
         <section>
           <h4>Proof Configuration (eddsa-jcs-2022)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-eddsa-jcs-2022">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are the <em>document</em>
+(|unsecuredDocument|) and the <em>proof options</em>
+(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>proofConfig</var> be an empty object.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>type</var> to
+<var>options</var>.<var>type</var>.
+            </li>
+            <li>
+If <var>options</var>.<var>cryptosuite</var> is set, set
+<var>proofConfig</var>.<var>cryptosuite</var> to its value.
+            </li>
+            <li>
+If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>created</var> to
+<var>options</var>.<var>created</var>. If the value is not a valid
+[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>verificationMethod</var> to
+<var>options</var>.<var>verificationMethod</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>proofPurpose</var> to
+<var>options</var>.<var>proofPurpose</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
+            </li>
+          </ol>
+
         </section>
         <section>
           <h4>Proof Serialization (eddsa-jcs-2022)</h4>

--- a/index.html
+++ b/index.html
@@ -698,7 +698,8 @@ that is used as input to the <a href="#hashing-eddsa-rdfc-2022">proof hashing al
           </p>
 
           <p>
-The required inputs to this algorithm are <em>proof options</em>
+The required inputs to this algorithm are the <em>document</em>
+(|unsecuredDocument|) and the <em>proof options</em>
 (<var>options</var>). The <em>proof options</em> MUST contain a type identifier
 for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
@@ -944,11 +945,96 @@ a [=verification result=], which is a [=struct=] whose
             </dd>
           </dl>
 
-          <p>
-The algorithm is the same as the one described in Section
-[[[#verify-proof-eddsa-rdfc-2022]]] with the changes outlined in
-Section [[[#eddsa-jcs-2022]]].
-          </p>
+          <ol class="algorithm">
+            <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+            </li>
+            <li>
+Let |proofOptions| be the result of a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+            </li>
+            <li>
+Let |proofBytes| be the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+value</a> in |securedDocument|.|proof|.|proofValue|.
+            </li>
+            <li>
+Perform the following checks  between the |securedDocument|.<var>@context</var> and
+the |proof|.<var>@context</var>:
+              <ol class="algorithm">
+                <li>
+The |securedDocument|.<var>@context</var> MUST contain all values contained in the
+|proof|.<var>@context</var> in the same order. Otherwise set |verified| to
+`false` and skip to the last step.
+                </li>
+                <li>
+The |securedDocument|.<var>@context</var> MUST NOT have any values preceding the
+values contained in the |proof|.<var>@context</var> but those MAY be followed by
+additional values not contained in the |proof|.<var>@context</var>. Otherwise
+set |verified| to `false` and skip to the last step.
+                </li>
+              </ol>
+
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section
+<a href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument| and
+|proofOptions| passed as parameters where step
+<strong>1)</strong> and step <strong>2)</strong> are replaced by the following
+text respectively:
+                <ol class="algorithm">
+                  <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+                  </li>
+                  <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+                  </li>
+                </ol>
+              </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration-eddsa-rdfc-2022]]] with
+|unsecuredDocument| and |proofOptions| passed as a parameters and where
+steps <strong>4)</strong> and
+<strong>9)</strong> are replaced by the following text respectively:
+                <ol class="algorithm">
+                  <li>
+If <var>options</var>.<var>type</var> is not set to
+`DataIntegrityProof` and <var>proofConfig</var>.<var>cryptosuite</var> is not
+set to `eddsa-jcs-2022`, an `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+                  </li>
+                  <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
+                  </li>
+                </ol>
+              </li>
+            <li>
+  Let |hashData| be the result of running the algorithm in Section
+  [[[#hashing-eddsa-rdfc-2022]]] with |transformedData| and |proofConfig|
+  passed as a parameters.
+            </li>
+            <li>
+  Let |verified:boolean| be the result of running the algorithm in Section
+  [[[#proof-verification-eddsa-rdfc-2022]]] algorithm on |hashData|,
+  |proofBytes|, and |proofConfig|.
+              </li>
+              <li>
+  Return a [=verification result=] with [=struct/items=]:
+                <dl data-link-for="verification result">
+                  <dt>[=verified=]</dt>
+                  <dd>|verified|</dd>
+                  <dt>[=verifiedDocument=]</dt>
+                  <dd>
+  |unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+                </dl>
+              </li>
+            </ol>
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -961,21 +961,25 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
             </li>
             <li>
 Perform the following checks  between the |securedDocument|.<var>@context</var> and
-the |proof|.<var>@context</var>:
+the |proofOptions|.<var>@context</var>:
               <ol class="algorithm">
                 <li>
 The |securedDocument|.<var>@context</var> MUST contain all values contained in the
-|proof|.<var>@context</var> in the same order. Otherwise set |verified| to
+|proofOptions|.<var>@context</var> in the same order. Otherwise set |verified| to
 `false` and skip to the last step.
                 </li>
                 <li>
 The |securedDocument|.<var>@context</var> MUST NOT have any values preceding the
-values contained in the |proof|.<var>@context</var> but those MAY be followed by
+values contained in the |proofOptions|.<var>@context</var> but those MAY be followed by
 additional values not contained in the |proof|.<var>@context</var>. Otherwise
 set |verified| to `false` and skip to the last step.
                 </li>
               </ol>
 
+            </li>
+            <li>
+Set |securedDocument|.<var>@context</var> equal to
+|proofOptions|.<var>@context</var>.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -912,7 +912,7 @@ Let |proofBytes| be the result of running the algorithm in Section
 |options| passed as parameters.
               </li>
               <li>
-Set <var>proof</var>.<var>@context</var>to
+Set <var>proof</var>.<var>@context</var> to
 <var>unsecuredDocument</var>.<var>@context</var>.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -1178,6 +1178,44 @@ Return <var>canonicalProofConfig</var>.
         </section>
         <section>
           <h4>Proof Serialization (eddsa-jcs-2022)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>) and
+<em>proof options</em> (<var>options</var>). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
+identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>privateKeyBytes</var> be the result of retrieving the
+private key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>proofBytes</var> be the result of applying the Edwards-Curve Digital
+Signature Algorithm (EdDSA) [[RFC8032]], using the `Ed25519` variant
+(Pure EdDSA), with <var>hashData</var> as the data to be signed using
+the private key specified by <var>privateKeyBytes</var>.
+<var>proofBytes</var> will be exactly 64 bytes in size.
+            </li>
+            <li>
+Return <var>proofBytes</var> as the <em>digital proof</em>.
+            </li>
+          </ol>
+
         </section>
         <section>
           <h4>Proof Verification (eddsa-jcs-2022)</h4>

--- a/index.html
+++ b/index.html
@@ -1219,6 +1219,42 @@ Return <var>proofBytes</var> as the <em>digital proof</em>.
         </section>
         <section>
           <h4>Proof Verification (eddsa-jcs-2022)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>),
+a digital signature (<var>proofBytes</var>) and
+proof options (<var>options</var>). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>publicKeyBytes</var> be the result of retrieving the
+public key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>verificationResult</var> be the result of applying the verification
+algorithm for the Edwards-Curve Digital Signature Algorithm (EdDSA)
+[[RFC8032]], using the `Ed25519` variant (Pure EdDSA),
+with <var>hashData</var> as the data to be verified against the
+<var>proofBytes</var> using the public key specified by
+<var>publicKeyBytes</var>.
+            </li>
+            <li>
+Return <var>verificationResult</var> as the <em>verification result</em>.
+            </li>
+          </ol>
+
         </section>
       </section>
 <!-- End of JCS section -->

--- a/index.html
+++ b/index.html
@@ -1004,8 +1004,8 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
+set to the string `eddsa-jcs-2022` then an error MUST be raised that
+SHOULD use the `MALFORMED_PROOF_ERROR` error code.
             </li>
             <li>
 Let <var>canonicalDocument</var> be the result of applying the

--- a/index.html
+++ b/index.html
@@ -862,6 +862,10 @@ is produced as output.
 
             <ol class="algorithm">
               <li>
+Set <var>options</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>.
+              </li>
+              <li>
 Let |proof| be a clone of the proof options, |options|.
               </li>
               <li>
@@ -883,10 +887,6 @@ passed as a parameters.
 Let |proofBytes| be the result of running the algorithm in Section
 [[[#proof-serialization-eddsa-jcs-2022]]] with |hashData| and
 |options| passed as parameters.
-              </li>
-              <li>
-Set <var>proof</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>.
               </li>
               <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
@@ -1106,10 +1106,6 @@ Set <var>proofConfig</var>.<var>verificationMethod</var> to
             <li>
 Set <var>proofConfig</var>.<var>proofPurpose</var> to
 <var>options</var>.<var>proofPurpose</var>.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>
             </li>
             <li>
 Let <var>canonicalProofConfig</var> be the result of applying the

--- a/index.html
+++ b/index.html
@@ -871,7 +871,7 @@ Set <var>proof</var>.<var>@context</var> to
               <li>
 Let |proofConfig| be the result of running the algorithm in
 Section [[[#proof-configuration-eddsa-jcs-2022]]] with
-|options| passed as a parameter.
+|proof| passed as a parameter.
               </li>
               <li>
 Let |transformedData| be the result of running the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@ object is produced as output.
 
           <ol class="algorithm">
             <li>
-Let <var>proofConfig</var> be an empty object.
+Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>type</var> to

--- a/index.html
+++ b/index.html
@@ -1082,14 +1082,6 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>type</var> to
-<var>options</var>.<var>type</var>.
-            </li>
-            <li>
-If <var>options</var>.<var>cryptosuite</var> is set, set
-<var>proofConfig</var>.<var>cryptosuite</var> to its value.
-            </li>
-            <li>
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.

--- a/index.html
+++ b/index.html
@@ -862,11 +862,11 @@ is produced as output.
 
             <ol class="algorithm">
               <li>
-Set <var>options</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>.
+Let |proof| be a clone of the proof options, |options|.
               </li>
               <li>
-Let |proof| be a clone of the proof options, |options|.
+Set <var>proof</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>.
               </li>
               <li>
 Let |proofConfig| be the result of running the algorithm in
@@ -875,8 +875,8 @@ Section [[[#proof-configuration-eddsa-jcs-2022]]] with
               </li>
               <li>
 Let |transformedData| be the result of running the algorithm in Section
-<a href="#transformation-eddsa-jcs-2022"></a> with |unsecuredDocument|,
-|proofConfig|, and |options| passed as parameters.
+<a href="#transformation-eddsa-jcs-2022"></a> with |unsecuredDocument|
+and |options| passed as parameters.
               </li>
               <li>
 Let |hashData| be the result of running the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -871,7 +871,7 @@ Set <var>proof</var>.<var>@context</var> to
               <li>
 Let |proofConfig| be the result of running the algorithm in
 Section [[[#proof-configuration-eddsa-jcs-2022]]] with
-|proof| passed as a parameter.
+|proof| passed as the <em>proof options</em> parameter.
               </li>
               <li>
 Let |transformedData| be the result of running the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -577,9 +577,11 @@ Let |transformedData| be the result of running the algorithm in Section <a
 href="#transformation-eddsa-rdfc-2022"></a> with |unsecuredDocument| and
 |proofOptions| passed as parameters.
           </li>
+          <li>
 Let |proofConfig| be the result of running the algorithm in Section <a
 href="#proof-configuration-eddsa-rdfc-2022"></a> with |unsecuredDocument| and
 |proofOptions| passed as parameters.
+          </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
 [[[#hashing-eddsa-rdfc-2022]]] with |transformedData| and |proofConfig|
@@ -2359,6 +2361,7 @@ to produce the final signed document as shown below.
           <pre class="example nohighlight" title="Signed Proof Chain (Extended)" data-include="TestVectors/proof-set-chain/signedProofChain2.json"
           data-include-format="text"></pre>
         </section>
+      </section>
     </section>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -1073,6 +1073,44 @@ Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
         </section>
         <section>
           <h4>Hashing (eddsa-jcs-2022)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section <a href="#proof-serialization-eddsa-jcs-2022"></a> or
+Section <a href="#proof-verification-eddsa-jcs-2022"></a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(<var>transformedDocument</var>) and <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>transformedDocumentHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
+be exactly 32 bytes in size.
+            </li>
+            <li>
+Let <var>proofConfigHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
+exactly 32 bytes in size.
+            </li>
+            <li>
+Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
+first hash) with <var>transformedDocumentHash</var> (the second hash).
+            </li>
+            <li>
+Return <var>hashData</var> as the <em>hash data</em>.
+            </li>
+          </ol>
+
         </section>
         <section>
           <h4>Proof Configuration (eddsa-jcs-2022)</h4>

--- a/index.html
+++ b/index.html
@@ -1033,9 +1033,58 @@ JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
               </li>
             </ol>
         </section>
+        <section>
+          <h4>Transformation (eddsa-jcs-2022)</h4>
 
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section <a href="#hashing-eddsa-jcs-2022"></a>.
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (<var>unsecuredDocument</var>) and
+transformation options (<var>options</var>). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `eddsa-jcs-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+            </li>
+            <li>
+Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>Hashing (eddsa-jcs-2022)</h4>
+        </section>
+        <section>
+          <h4>Proof Configuration (eddsa-jcs-2022)</h4>
+        </section>
+        <section>
+          <h4>Proof Serialization (eddsa-jcs-2022)</h4>
+        </section>
+        <section>
+          <h4>Proof Verification (eddsa-jcs-2022)</h4>
+        </section>
       </section>
-
+<!-- End of JCS section -->
     </section>
 
     <section>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/225 to properly handle `@context` injection issues that could arise with JCS. Note that this also applies to `@context` issues that could arise with proof sets/chains with JCS. This PR contains **normative** changes to the *Create Proof (eddsa-jcs-2022)* and *Verify Proof (eddsa-jcs-2022)* algorithms.

This PR does **NOT** include **informative** text such as:

1. Explanation of why these steps are necessary and sufficient. Such informative text is present in the discussions of issue  https://github.com/w3c/vc-data-integrity/issues/225 and could be extracted and included somewhere in the document. Thoughts?
2. Updates to the current *eddsa-jcs-2022* test vectors in the specification. Will be updated after this PR is reviewed.
3. Explicit test vectors illustrating these procedures in a realistic example. Is this desirable/necessary? Thoughts


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/79.html" title="Last updated on Jun 9, 2024, 4:07 PM UTC (c49c133)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/79/0944119...Wind4Greg:c49c133.html" title="Last updated on Jun 9, 2024, 4:07 PM UTC (c49c133)">Diff</a>