### PR TITLE
Unify error codes and error handling language

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,7 +632,7 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-rdfc-2022` then an error MUST be raised and SHOULD
+set to the string `eddsa-rdfc-2022`, an error MUST be raised and SHOULD
 convey an error type of `PROOF_TRANSFORMATION_ERROR`.
             </li>
             <li>
@@ -1009,8 +1009,8 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-jcs-2022` then an error MUST be raised that
-SHOULD use the `PROOF_VERIFICATION_ERROR` error code.
+set to the string `eddsa-jcs-2022`, an error MUST be raised and
+SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Let <var>canonicalDocument</var> be the result of applying the

--- a/index.html
+++ b/index.html
@@ -632,8 +632,8 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `eddsa-rdfc-2022` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
+set to the string `eddsa-rdfc-2022` then an error MUST be raised and SHOULD
+convey an error type of `PROOF_TRANSFORMATION_ERROR`.
             </li>
             <li>
 Let |canonicalDocument| be the result of converting |unsecuredDocument|
@@ -724,13 +724,16 @@ If <var>options</var>.<var>cryptosuite</var> is set, set
             </li>
             <li>
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
-<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-rdfc-2022`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-rdfc-2022`,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>created</var> to
 <var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+[[XMLSCHEMA11-2]] datetime,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>verificationMethod</var> to
@@ -1007,7 +1010,7 @@ encoding.
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
 set to the string `eddsa-jcs-2022` then an error MUST be raised that
-SHOULD use the `MALFORMED_PROOF_ERROR` error code.
+SHOULD use the `PROOF_VERIFICATION_ERROR` error code.
             </li>
             <li>
 Let <var>canonicalDocument</var> be the result of applying the
@@ -1086,13 +1089,16 @@ Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
-<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>created</var> to
 <var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+[[XMLSCHEMA11-2]] datetime,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>verificationMethod</var> to
@@ -2018,7 +2024,8 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
             <ol class="algorithm">
               <li>
   If <var>options</var>.<var>type</var> is not set to the string
-  `Ed25519Signature2020`, then a `PROOF_TRANSFORMATION_ERROR` MUST be raised.
+  `Ed25519Signature2020`, an error MUST be raised and SHOULD convey an error
+  type of `PROOF_TRANSFORMATION_ERROR`.
               </li>
               <li>
   Let |canonicalDocument| be the result of converting |unsecuredDocument|
@@ -2113,13 +2120,15 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
   <var>proofConfig</var>.<var>cryptosuite</var> to its value.
               </li>
               <li>
-  If <var>options</var>.<var>type</var> is not set to `Ed25519Signature2020`, an
-  `INVALID_PROOF_CONFIGURATION` error MUST be raised.
+If <var>options</var>.<var>type</var> is not set to `Ed25519Signature2020`,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
               </li>
               <li>
   Set <var>proofConfig</var>.<var>created</var> to
   <var>options</var>.<var>created</var>. If the value is not a valid
-  [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+  [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
+  error type of `PROOF_GENERATION_ERROR `.
               </li>
               <li>
   Set <var>proofConfig</var>.<var>verificationMethod</var> to

--- a/index.html
+++ b/index.html
@@ -633,7 +633,8 @@ encoding.
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
 set to the string `eddsa-rdfc-2022` then an error MUST be raised and SHOULD
-convey an error type of `PROOF_TRANSFORMATION_ERROR`.
+convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_TRANSFORMATION_ERROR">PROOF_TRANSFORMATION_ERROR</a>.
             </li>
             <li>
 Let |canonicalDocument| be the result of converting |unsecuredDocument|
@@ -726,14 +727,14 @@ If <var>options</var>.<var>cryptosuite</var> is set, set
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-rdfc-2022`,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>created</var> to
 <var>options</var>.<var>created</var>. If the value is not a valid
 [[XMLSCHEMA11-2]] datetime,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>verificationMethod</var> to
@@ -1010,7 +1011,9 @@ encoding.
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
 set to the string `eddsa-jcs-2022` then an error MUST be raised that
-SHOULD use the `PROOF_VERIFICATION_ERROR` error code.
+SHOULD use the
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>
+error code.
             </li>
             <li>
 Let <var>canonicalDocument</var> be the result of applying the
@@ -1091,14 +1094,14 @@ Let <var>proofConfig</var> be a clone of the <var>options</var> object.
 If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>created</var> to
 <var>options</var>.<var>created</var>. If the value is not a valid
 [[XMLSCHEMA11-2]] datetime,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>verificationMethod</var> to
@@ -2025,7 +2028,8 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
               <li>
   If <var>options</var>.<var>type</var> is not set to the string
   `Ed25519Signature2020`, an error MUST be raised and SHOULD convey an error
-  type of `PROOF_TRANSFORMATION_ERROR`.
+  type of
+  <a data-cite="VC-DATA-INTEGRITY#PROOF_TRANSFORMATION_ERROR">PROOF_TRANSFORMATION_ERROR</a>.
               </li>
               <li>
   Let |canonicalDocument| be the result of converting |unsecuredDocument|
@@ -2122,13 +2126,14 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
               <li>
 If <var>options</var>.<var>type</var> is not set to `Ed25519Signature2020`,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
               </li>
               <li>
   Set <var>proofConfig</var>.<var>created</var> to
   <var>options</var>.<var>created</var>. If the value is not a valid
   [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
-  error type of `PROOF_GENERATION_ERROR `.
+  error type of
+  <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
               </li>
               <li>
   Set <var>proofConfig</var>.<var>verificationMethod</var> to


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-eddsa/issues/82.
It updates the document to use three main error codes (PROOF_TRANSFORMATION_ERROR, PROOF_GENERATION_ERROR, and PROOF_VERIFICATION_ERROR. ) and adds appropriate language on raising and conveying errors where appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/84.html" title="Last updated on Jun 30, 2024, 4:15 PM UTC (401f365)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/84/0fa95aa...Wind4Greg:401f365.html" title="Last updated on Jun 30, 2024, 4:15 PM UTC (401f365)">Diff</a>