### PR TITLE
Incorporate additional custom proof options

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@ Return |cryptosuite|.
 
         <p>
 The `eddsa-rdfc-2022` cryptographic suite takes an input document, canonicalizes
-the document using the RDF Dataset Canonicalization algorithm [[RDF-CANON]], and then 
+the document using the RDF Dataset Canonicalization algorithm [[RDF-CANON]], and then
 cryptographically hashes and signs the output
 resulting in the production of a data integrity proof. The algorithms in this
 section also include the verification of such a data integrity proof.
@@ -710,50 +710,33 @@ cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
 identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
 object is produced as output.
           </p>
-
           <ol class="algorithm">
             <li>
-Let <var>proofConfig</var> be an empty object.
+Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>type</var> to
-<var>options</var>.<var>type</var>.
-            </li>
-            <li>
-If <var>options</var>.<var>cryptosuite</var> is set, set
-<var>proofConfig</var>.<var>cryptosuite</var> to its value.
-            </li>
-            <li>
-If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
-<var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-rdfc-2022`,
-an error MUST be raised and SHOULD convey an error type of
+If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
+|proofConfig|.|cryptosuite| is not set to `eddsa-rdfc-2022`, an
+error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>created</var> to
-<var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime,
-an error MUST be raised and SHOULD convey an error type of
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be
+raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>verificationMethod</var> to
-<var>options</var>.<var>verificationMethod</var>.
+Set |proofConfig|.<var>@context </var>to
+|unsecuredDocument|.<var>@contex</var>t.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>proofPurpose</var> to
-<var>options</var>.<var>proofPurpose</var>.
+Let |canonicalProofConfig| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |proofConfig|.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>
-            </li>
-            <li>
-Let <var>canonicalProofConfig</var> be the result of applying the
-RDF Dataset Canonicalization algorithm [[RDF-CANON]] to the <var>proofConfig</var>.
-            </li>
-            <li>
-Return <var>canonicalProofConfig</var>.
+Return |canonicalProofConfig|.
             </li>
           </ol>
 
@@ -1090,25 +1073,16 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`,
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>created</var> to
-<var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime,
-an error MUST be raised and SHOULD convey an error type of
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be
+raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>verificationMethod</var> to
-<var>options</var>.<var>verificationMethod</var>.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>proofPurpose</var> to
-<var>options</var>.<var>proofPurpose</var>.
             </li>
             <li>
 Let <var>canonicalProofConfig</var> be the result of applying the
@@ -1953,7 +1927,7 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
 
           <p>
   The `Ed25519Signature2020` cryptographic suite takes an input document,
-  canonicalizes the document using the RDF Dataset Canonicalization algorithm [[RDF-CANON]], 
+  canonicalizes the document using the RDF Dataset Canonicalization algorithm [[RDF-CANON]],
   and then cryptographically hashes and signs the output
   resulting in the production of a data integrity proof. The algorithms in this
   section also include the verification of such a data integrity proof.
@@ -2112,35 +2086,18 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
 
             <ol class="algorithm">
               <li>
-  Let <var>proofConfig</var> be an empty object.
+Let |proofConfig| be a clone of the |options| object.
               </li>
               <li>
-  Set <var>proofConfig</var>.<var>type</var> to
-  <var>options</var>.<var>type</var>.
-              </li>
-              <li>
-  If <var>options</var>.<var>cryptosuite</var> is set, set
-  <var>proofConfig</var>.<var>cryptosuite</var> to its value.
-              </li>
-              <li>
-If <var>options</var>.<var>type</var> is not set to `Ed25519Signature2020`,
+If <var>proofConfig</var>.<var>type</var> is not set to `Ed25519Signature2020`,
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
               </li>
               <li>
-  Set <var>proofConfig</var>.<var>created</var> to
-  <var>options</var>.<var>created</var>. If the value is not a valid
-  [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
-  error type of
-  <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
-              </li>
-              <li>
-  Set <var>proofConfig</var>.<var>verificationMethod</var> to
-  <var>options</var>.<var>verificationMethod</var>.
-              </li>
-              <li>
-  Set <var>proofConfig</var>.<var>proofPurpose</var> to
-  <var>options</var>.<var>proofPurpose</var>.
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be
+raised and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
               </li>
               <li>
   Set <var>proofConfig</var>.<var>@context</var> to

--- a/index.html
+++ b/index.html
@@ -721,18 +721,18 @@ error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
-If |proofConfig|.|created| is set and if the value is not a
+If |proofConfig|.|created| is set to a value that is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be
 raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set |proofConfig|.<var>@context </var>to
-|unsecuredDocument|.<var>@contex</var>t.
+|unsecuredDocument|.<var>@context</var>.
             </li>
             <li>
 Let |canonicalProofConfig| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
+RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]] to the |proofConfig|.
             </li>
             <li>
@@ -1073,13 +1073,13 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and/or
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`,
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
-If |proofConfig|.|created| is set and if the value is not a
+If |proofConfig|.|created| is set to a value that is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be
 raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
@@ -1928,7 +1928,7 @@ unlinkability. If signatures are re-used, they can be used as correlatable data.
           <p>
   The `Ed25519Signature2020` cryptographic suite takes an input document,
   canonicalizes the document using the RDF Dataset Canonicalization algorithm [[RDF-CANON]],
-  and then cryptographically hashes and signs the output
+  and then cryptographically hashes and signs the output,
   resulting in the production of a data integrity proof. The algorithms in this
   section also include the verification of such a data integrity proof.
           </p>
@@ -2094,7 +2094,7 @@ an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
               </li>
               <li>
-If |proofConfig|.|created| is set and if the value is not a
+If |proofConfig|.|created| is set to a value that is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be
 raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.

--- a/index.html
+++ b/index.html
@@ -1062,7 +1062,7 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and/or
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` or
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `eddsa-jcs-2022`,
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.

--- a/index.html
+++ b/index.html
@@ -2094,7 +2094,7 @@ an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
               </li>
               <li>
-If |proofConfig|.|created| is set to a value that is not a
+If |proofConfig|.|created| is present and set to a value that is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be
 raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.

--- a/index.html
+++ b/index.html
@@ -721,7 +721,7 @@ error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
-If |proofConfig|.|created| is set to a value that is not a
+If |proofConfig|.|created| is present and set to a value that is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be
 raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-eddsa/issues/74. It updates the proof configuration procedures to use a clone of the options input and then updates the procedures accordingly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/88.html" title="Last updated on Jul 15, 2024, 4:02 PM UTC (a66c754)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/88/b41cbf7...Wind4Greg:a66c754.html" title="Last updated on Jul 15, 2024, 4:02 PM UTC (a66c754)">Diff</a>