### PR TITLE
Exchanged bullet points in hashing algorithm section (issue 92)

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,8 +671,9 @@ to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
 be exactly 32 bytes in size.
             </li>
             <li>
-Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
-first hash) with <var>transformedDocumentHash</var> (the second hash).
+Let <var>hashData</var> be the result of concatenating <var>proofConfigHash</var>
+(the first hash produced above) followed by <var>transformedDocumentHash</var>
+(the second hash produced above).
             </li>
             <li>
 Return <var>hashData</var> as the <em>hash data</em>.

--- a/index.html
+++ b/index.html
@@ -659,16 +659,16 @@ series of bytes is produced as output.
 
           <ol class="algorithm">
             <li>
+              Let <var>proofConfigHash</var> be the result of applying the
+              SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+              to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
+              exactly 32 bytes in size.
+            </li>
+            <li>
 Let <var>transformedDocumentHash</var> be the result of applying the
 SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
 to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
 be exactly 32 bytes in size.
-            </li>
-            <li>
-Let <var>proofConfigHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
-exactly 32 bytes in size.
             </li>
             <li>
 Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the

--- a/index.html
+++ b/index.html
@@ -659,10 +659,10 @@ series of bytes is produced as output.
 
           <ol class="algorithm">
             <li>
-              Let <var>proofConfigHash</var> be the result of applying the
-              SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-              to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
-              exactly 32 bytes in size.
+Let <var>proofConfigHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
+exactly 32 bytes in size.
             </li>
             <li>
 Let <var>transformedDocumentHash</var> be the result of applying the


### PR DESCRIPTION
This is a proposal to settle #92. It exchanges the order of two bullet points, making the back references to the hashes in sync with both possible interpretations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/pull/94.html" title="Last updated on Aug 5, 2024, 3:06 PM UTC (dc70dc9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/94/4e3bb98...dc70dc9.html" title="Last updated on Aug 5, 2024, 3:06 PM UTC (dc70dc9)">Diff</a>