### PR TITLE
Editorial review: terminology,  clarity, reference consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,8 +169,8 @@ ol.algorithm li:before {
     <section id="abstract">
       <p>
 This specification describes a Data Integrity cryptographic suite for use when
-creating or verifying a digital signature using the twisted Edwards Curve
-Digital Signature Algorithm (EdDSA) and Curve25519 (ed25519).
+creating or verifying a digital signature using the the Ed25519 instantiation 
+of the Edwards-Curve Digital Signature Algorithm (EdDSA).
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -115,16 +115,16 @@
         otherLinks: [{
           key: "Related Specifications",
           data: [{
-            value: "The Verifiable Credentials Data Model v2.0",
+            value: "Verifiable Credentials Data Model v2.0",
             href: "https://www.w3.org/TR/vc-data-model-2.0/"
           }, {
             value: "Verifiable Credential Data Integrity v1.0",
             href: "https://www.w3.org/TR/vc-data-integrity/"
           }, {
-            value: "The Elliptic Curve Digital Signature Algorithm Cryptosuites v1.0",
+            value: "Data Integrity ECDSA Cryptosuites v1.0",
             href: "https://www.w3.org/TR/vc-di-ecdsa/"
           }, {
-            value: "The BBS Digital Signature Algorithm Cryptosuites v1.0",
+            value: "Data Integrity BBS Cryptosuites v1.0",
             href: "https://www.w3.org/TR/vc-di-bbs/"
           }]
         }]

--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@ signatures.
 
           <p>
 The <a data-cite="controller-document#multikey">Multikey format</a>, defined in
-[[controller-document]], is used to express public keys for the cryptographic
+[[[controller-document]]], is used to express public keys for the cryptographic
 suites defined in this specification.
           </p>
 
@@ -279,7 +279,7 @@ suites defined in this specification.
 The `publicKeyMultibase` value of the verification method MUST start with the
 base-58-btc prefix (`z`), as defined in the
 <a data-cite="controller-document#multibase-0">Multibase section</a> of
-[[controller-document]]. A Multibase-encoded Multikey value follows, which MUST
+[[[controller-document]]]. A Multibase-encoded Multikey value follows, which MUST
 consist of a binary value that starts with the two-byte prefix `0xed01`, which
 is the Multikey header for an Ed25519 public key, followed by the 32-byte public
 key data, all of which is then encoded using base-58-btc. Any other encoding
@@ -377,7 +377,7 @@ The `proofValue` property of the proof MUST be a detached EdDSA signature
 produced according to [[RFC8032]], encoded using the base-58-btc header and
 alphabet as described in the
 <a data-cite="controller-document#multibase-0">Multibase section</a> of
-[[controller-document]].
+[[[controller-document]]].
           </p>
 
           <pre class="example nohighlight"
@@ -412,7 +412,7 @@ alphabet as described in the
 
       <p>
 The following section describes multiple Data Integrity cryptographic suites
-that utilize the Edwards-Curve Digital Signature Algorithm.
+that use the Edwards-Curve Digital Signature Algorithm.
       </p>
 
       <section>
@@ -799,7 +799,7 @@ represented as a boolean value is produced as output.
 Let `publicKeyBytes` be the result of retrieving the
 public key bytes associated with the
 `options`.`verificationMethod` value as described in the
-[[controller-document]] specification,
+[[[controller-document]]] specification,
 <a data-cite="controller-document#retrieve-verification-method">
 Section 3.3: Retrieve Verification Method</a>.
             </li>

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@ implementation report</a>.
 This specification defines a cryptographic suite for the purpose of creating,
 verifying proofs for Ed25519 EdDSA signatures in conformance with the
 Data Integrity [[VC-DATA-INTEGRITY]] specification. The approach is
-accepted by the U.S. National Institute of Standards in the latest FIPS 186-5
+accepted by the U.S. National Institute of Standards in the latest [[FIPS-186-5]]
 publication and meets U.S. Federal Information Processing requirements when
 using cryptography to secure digital information.
       </p>

--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@ Let |proofBytes| be the result of running the algorithm in Section
 |options| passed as parameters.
             </li>
             <li>
-Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+Let |proof|.|proofValue| be a <a data-cite="controller-document#multibase-0">
 base58-btc-encoded Multibase value</a> of the |proofBytes|.
             </li>
             <li>
@@ -561,7 +561,7 @@ removed.
           </li>
           <li>
 Let |proofBytes| be the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+<a data-cite="controller-document#multibase-0">Multibase decoded base58-btc
 value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
@@ -761,8 +761,8 @@ Let `privateKeyBytes` be the result of retrieving the
 private key bytes associated with the
 `options`.`verificationMethod` value as described in the
 Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+<a data-cite="vc-data-integrity#processing-model">
+Section 4.1: Processing Model</a>.
             </li>
             <li>
 Let `proofBytes` be the result of applying the Edwards-Curve Digital
@@ -799,9 +799,9 @@ represented as a boolean value is produced as output.
 Let `publicKeyBytes` be the result of retrieving the
 public key bytes associated with the
 `options`.`verificationMethod` value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+[[controller-document]] specification,
+<a data-cite="controller-document#retrieve-verification-method">
+Section 3.3: Retrieve Verification Method</a>.
             </li>
             <li>
 Let `verificationResult` be the result of applying the verification

--- a/index.html
+++ b/index.html
@@ -121,6 +121,9 @@
             value: "Verifiable Credential Data Integrity v1.0",
             href: "https://www.w3.org/TR/vc-data-integrity/"
           }, {
+            value: "Controller Documents v1.0",
+            href: "https://www.w3.org/TR/controller-document/"
+          },{
             value: "Data Integrity ECDSA Cryptosuites v1.0",
             href: "https://www.w3.org/TR/vc-di-ecdsa/"
           }, {

--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@ alphabet as described in the
 
       <p>
 The following section describes multiple Data Integrity cryptographic suites
-that utilize the twisted Edwards Curve Digital Signature Algorithm.
+that utilize the Edwards-Curve Digital Signature Algorithm.
       </p>
 
       <section>
@@ -421,7 +421,7 @@ that utilize the twisted Edwards Curve Digital Signature Algorithm.
         <p>
 This algorithm is used to configure a cryptographic suite to be used by the
 <a data-cite="VC-DATA-INTEGRITY#add-proof">Add Proof</a> and
-<a href="VC-DATA-INTEGRITY#verify-proof">Verify Proof</a>
+<a data-cite="VC-DATA-INTEGRITY#verify-proof">Verify Proof</a>
 functions in [[[VC-DATA-INTEGRITY]]]. The algorithm takes an options object
 ([=map=] |options|) as input and returns a [=data integrity cryptographic suite
 instance|cryptosuite instance=] ([=struct=] |cryptosuite|).
@@ -438,11 +438,11 @@ If |options|.|type| does not equal `DataIntegrityProof`, return |cryptosuite|.
 If |options|.|cryptosuite| is `eddsa-rdfc-2022`:
             <ol class="algorithm">
               <li>
-Set |cryptosuite|.|createProof| to the result of running the algorithm in Section
+Set |cryptosuite|.|createProof| to the algorithm in Section
 [[[#create-proof-eddsa-rdfc-2022]]].
               </li>
               <li>
-Set |cryptosuite|.|verifyProof| to the result of running the algorithm in Section
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
 [[[#verify-proof-eddsa-rdfc-2022]]].
               </li>
             </ol>
@@ -451,11 +451,11 @@ Set |cryptosuite|.|verifyProof| to the result of running the algorithm in Sectio
 If |options|.|cryptosuite| is `eddsa-jcs-2022`:
             <ol class="algorithm">
               <li>
-Set |cryptosuite|.|createProof| to the result of running the algorithm in Section
+Set |cryptosuite|.|createProof| to the algorithm in Section
 [[[#create-proof-eddsa-jcs-2022]]].
               </li>
               <li>
-Set |cryptosuite|.|verifyProof| to the result of running the algorithm in Section
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
 [[[#verify-proof-eddsa-jcs-2022]]].
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -270,16 +270,16 @@ signatures.
           <h4>Multikey</h4>
 
           <p>
-The <a data-cite="VC-DATA-INTEGRITY#multikey">Multikey format</a>, defined in
-[[VC-DATA-INTEGRITY]], is used to express public keys for the cryptographic
+The <a data-cite="controller-document#multikey">Multikey format</a>, defined in
+[[controller-document]], is used to express public keys for the cryptographic
 suites defined in this specification.
           </p>
 
           <p>
 The `publicKeyMultibase` value of the verification method MUST start with the
 base-58-btc prefix (`z`), as defined in the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase section</a> of
-[[VC-DATA-INTEGRITY]]. A Multibase-encoded Multikey value follows, which MUST
+<a data-cite="controller-document#multibase-0">Multibase section</a> of
+[[controller-document]]. A Multibase-encoded Multikey value follows, which MUST
 consist of a binary value that starts with the two-byte prefix `0xed01`, which
 is the Multikey header for an Ed25519 public key, followed by the 32-byte public
 key data, all of which is then encoded using base-58-btc. Any other encoding
@@ -373,11 +373,11 @@ The `type` property MUST be `DataIntegrityProof`.
 The `cryptosuite` property of the proof MUST be `eddsa-rdfc-2022` or `eddsa-jcs-2022`.
           </p>
           <p>
-The `proofValue` property of the proof MUST be a detached EdDSA
+The `proofValue` property of the proof MUST be a detached EdDSA signature
 produced according to [[RFC8032]], encoded using the base-58-btc header and
 alphabet as described in the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase section</a> of
-[[VC-DATA-INTEGRITY]].
+<a data-cite="controller-document#multibase-0">Multibase section</a> of
+[[controller-document]].
           </p>
 
           <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -872,7 +872,7 @@ Let |proofBytes| be the result of running the algorithm in Section
 |options| passed as parameters.
               </li>
               <li>
-Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+Let |proof|.|proofValue| be a <a data-cite="controller-document#multibase-0">
 base58-btc-encoded Multibase value</a> of the |proofBytes|.
               </li>
               <li>
@@ -911,7 +911,7 @@ Let |proofOptions| be the result of a copy of |securedDocument|.|proof| with
             </li>
             <li>
 Let |proofBytes| be the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+<a data-cite="controller-document#multibase-0">Multibase decoded base58-btc
 value</a> in |securedDocument|.|proof|.|proofValue|.
             </li>
             <li>
@@ -1811,7 +1811,7 @@ The `controller` of the verification method MUST be a URL.
             <p>
 The `publicKeyMultibase` value of the verification method MUST start with the
 base-58-btc prefix (`z`), as defined in the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase section</a> of
+<a data-cite="controller-document#multibase-0">Multibase section</a> of
 [[VC-DATA-INTEGRITY]]. A Multibase-encoded Multikey value follows, which MUST
 consist of a binary value that starts with the two-byte prefix `0xed01`, which
 is the Multikey header for an Ed25519 public key, followed by the 32-byte


### PR DESCRIPTION
This PR  contains editorial (informative) corrections to  terminology (updates  the  EdDSA terminology based on RFC8032 and FIPS 186-5), small  clarity items (missing words),  and references to items  that have  moved between  referenced specs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/95.html" title="Last updated on Aug 23, 2024, 9:51 PM UTC (325920d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/95/53bfa73...Wind4Greg:325920d.html" title="Last updated on Aug 23, 2024, 9:51 PM UTC (325920d)">Diff</a>