### PR TITLE
Reference to canonical form (in n-quads) instead of directly n-qads

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,7 +619,7 @@ cryptographic suite</a> (`type`) and a cryptosuite
 identifier (`cryptosuite`). A <em>transformed data document</em> is
 produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
 encoding.
-          </p><a data-cite="rdf-canon#serialization"></a>
+          </p>
 
           <ol class="algorithm">
             <li>

--- a/index.html
+++ b/index.html
@@ -619,7 +619,7 @@ cryptographic suite</a> (`type`) and a cryptosuite
 identifier (`cryptosuite`). A <em>transformed data document</em> is
 produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
 encoding.
-          </p>
+          </p><a data-cite="rdf-canon#serialization"></a>
 
           <ol class="algorithm">
             <li>
@@ -632,9 +632,9 @@ an error MUST be raised that SHOULD convey an error type of
             <li>
 Let |canonicalDocument| be the result of converting |unsecuredDocument|
 <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">
-to RDF statements</a>, applying the RDF Dataset Canonicalization
-Algorithm [[RDF-CANON]] to the result, and then serializing the result to
-[[N-QUADS]].
+  to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">RDF Dataset Canonicalization
+Algorithm</a> [[RDF-CANON]] to the result, and then serializing the result to a
+<a data-cite="RDF-CANON#dfn-serialized-canonical-form">serialized canonical form</a> [[RDF-CANON]].
             </li>
             <li>
 Return `canonicalDocument` as the <em>transformed data document</em>.
@@ -2012,8 +2012,8 @@ Let |canonicalDocument| be the result of converting |unsecuredDocument| to
 <a data-cite="JSON-LD11-API#expansion-algorithm">JSON-LD expanded form</a>
 and then <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">
 to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">
-Universal RDF Dataset Canonicalization Algorithm</a>, and then serializing the
-result to [[N-QUADS]].
+Universal RDF Dataset Canonicalization Algorithm</a>, and then serializing the result to a
+<a data-cite="RDF-CANON#dfn-serialized-canonical-form">serialized canonical form</a>.
               </li>
               <li>
 Return `canonicalDocument` as the <em>transformed data document</em>.

--- a/index.html
+++ b/index.html
@@ -632,7 +632,7 @@ an error MUST be raised that SHOULD convey an error type of
             <li>
 Let |canonicalDocument| be the result of converting |unsecuredDocument|
 <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">
-  to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">RDF Dataset Canonicalization
+to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">RDF Dataset Canonicalization
 Algorithm</a> [[RDF-CANON]] to the result, and then serializing the result to a
 <a data-cite="RDF-CANON#dfn-serialized-canonical-form">serialized canonical form</a> [[RDF-CANON]].
             </li>


### PR DESCRIPTION
This was raised as an ECDSA issue (https://github.com/w3c/vc-di-ecdsa/issues/75), but it is equally valid for EdDSA: just referring to N-QUADS as a result of canonicalization is not correct, it should refer to the canonical format. The change here is minimal: change in references, essentially.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/pull/98.html" title="Last updated on Sep 13, 2024, 3:59 AM UTC (4545b01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/98/c3b58d0...4545b01.html" title="Last updated on Sep 13, 2024, 3:59 AM UTC (4545b01)">Diff</a>