### PR TITLE
Update extended proof chain test vectors

### DIFF
--- a/TestVectors/proof-set-chain/proofChainConfig2.json
+++ b/TestVectors/proof-set-chain/proofChainConfig2.json
@@ -2,7 +2,7 @@
   "type": "DataIntegrityProof",
   "cryptosuite": "eddsa-rdfc-2022",
   "created": "2023-02-26T22:16:38Z",
-  "verificationMethod": "did:key:z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+  "verificationMethod": "did:key:z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT#z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT",
   "proofPurpose": "assertionMethod",
   "previousProof": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23"
 }

--- a/TestVectors/proof-set-chain/proofChainConfigSigned2.json
+++ b/TestVectors/proof-set-chain/proofChainConfigSigned2.json
@@ -2,8 +2,8 @@
   "type": "DataIntegrityProof",
   "cryptosuite": "eddsa-rdfc-2022",
   "created": "2023-02-26T22:16:38Z",
-  "verificationMethod": "did:key:z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+  "verificationMethod": "did:key:z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT#z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT",
   "proofPurpose": "assertionMethod",
   "previousProof": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
-  "proofValue": "z21Royb2jnpDY8GkvsTn3pwWxXiXRMEwNLSzrfERHb1TNtDBydnFqwtxY9Vypv2mwMPygJhuxbKs2QLyGHx9DBjmY"
+  "proofValue": "z4b5uUtxNiV4E541LiR8qLvA21xM1Vt4Hfn6nLmmDePdFvLB3jFj3HyEEJyRMbpJzv4Gfdr8ABeuRTxAvZv6KWRRh"
 }

--- a/TestVectors/proof-set-chain/signedProofChain2.json
+++ b/TestVectors/proof-set-chain/signedProofChain2.json
@@ -52,10 +52,10 @@
       "type": "DataIntegrityProof",
       "cryptosuite": "eddsa-rdfc-2022",
       "created": "2023-02-26T22:16:38Z",
-      "verificationMethod": "did:key:z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1#z6MkmEq87wkHCYnWnNZkigeDMGTN7oUw1upkhzd77KuXERS1",
+      "verificationMethod": "did:key:z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT#z6Mkm1S51iPHJvDEkJ9MRtxJmT8Pqo6wHipAFwBAjN83vntT",
       "proofPurpose": "assertionMethod",
       "previousProof": "urn:uuid:d94f792a-c546-4d06-b38a-da070ab56c23",
-      "proofValue": "z21Royb2jnpDY8GkvsTn3pwWxXiXRMEwNLSzrfERHb1TNtDBydnFqwtxY9Vypv2mwMPygJhuxbKs2QLyGHx9DBjmY"
+      "proofValue": "z4b5uUtxNiV4E541LiR8qLvA21xM1Vt4Hfn6nLmmDePdFvLB3jFj3HyEEJyRMbpJzv4Gfdr8ABeuRTxAvZv6KWRRh"
     }
   ]
 }


### PR DESCRIPTION
This PR fixes the **extended proof chain test vectors** to  use all four public/private key pairs as documented in the specification text. The previous test vectors repeated the use of public/private key number 3 rather than using key number 4. **Note**: test vectors are ***informative***.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/99.html" title="Last updated on Oct 2, 2024, 7:54 PM UTC (c1bb00d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/99/7e067ae...Wind4Greg:c1bb00d.html" title="Last updated on Oct 2, 2024, 7:54 PM UTC (c1bb00d)">Diff</a>