### PR TITLE
Fixed references and text on how to obtain key material

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,12 +765,10 @@ represented as series of bytes is produced as output.
 
           <ol class="algorithm">
             <li>
-Let `privateKeyBytes` be the result of retrieving the
-private key bytes associated with the
-`options`.`verificationMethod` value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#processing-model">
-Section 4.1: Processing Model</a>.
+Let |privateKeyBytes| be the result of retrieving the
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+|options|.|verificationMethod| value.
             </li>
             <li>
 Let `proofBytes` be the result of applying the Edwards-Curve Digital
@@ -804,12 +802,12 @@ represented as a boolean value is produced as output.
 
           <ol class="algorithm">
             <li>
-Let `publicKeyBytes` be the result of retrieving the
+Let |publicKeyBytes| be the result of retrieving the
 public key bytes associated with the
-`options`.`verificationMethod` value as described in the
+|options|.|verificationMethod| value as described in the
 [[[controller-document]]] specification,
 <a data-cite="controller-document#retrieve-verification-method">
-Section 3.3: Retrieve Verification Method</a>.
+Section: Retrieve Verification Method</a>.
             </li>
             <li>
 Let `verificationResult` be the result of applying the verification
@@ -1116,12 +1114,10 @@ represented as series of bytes is produced as output.
 
           <ol class="algorithm">
             <li>
-Let `privateKeyBytes` be the result of retrieving the
-private key bytes associated with the
-`options`.`verificationMethod` value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+Let |privateKeyBytes| be the result of retrieving the
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+|options|.|verificationMethod| value.
             </li>
             <li>
 Let `proofBytes` be the result of applying the Edwards-Curve Digital
@@ -1153,13 +1149,13 @@ represented as a boolean value is produced as output.
           </p>
 
           <ol class="algorithm">
-            <li>
-Let `publicKeyBytes` be the result of retrieving the
+          <li>
+Let |publicKeyBytes| be the result of retrieving the
 public key bytes associated with the
-`options`.`verificationMethod` value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+|options|.|verificationMethod| value as described in the
+[[[controller-document]]] specification,
+<a data-cite="controller-document#retrieve-verification-method">
+Section: Retrieve Verification Method</a>.
             </li>
             <li>
 Let `verificationResult` be the result of applying the verification
@@ -2164,12 +2160,10 @@ represented as series of bytes is produced as output.
 
             <ol class="algorithm">
               <li>
-Let `privateKeyBytes` be the result of retrieving the
-private key bytes associated with the
-`options`.`verificationMethod` value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+Let |privateKeyBytes| be the result of retrieving the
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+|options|.|verificationMethod| value.
               </li>
               <li>
 Let `proofBytes` be the result of applying the Edwards-Curve Digital
@@ -2203,12 +2197,12 @@ represented as a boolean value is produced as output.
 
             <ol class="algorithm">
               <li>
-Let `publicKeyBytes` be the result of retrieving the
+Let |publicKeyBytes| be the result of retrieving the
 public key bytes associated with the
-`options`.`verificationMethod` value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+|options|.|verificationMethod| value as described in the
+[[[controller-document]]] specification,
+<a data-cite="controller-document#retrieve-verification-method">
+Section: Retrieve Verification Method</a>.
               </li>
               <li>
 Let `verificationResult` be the result of applying the verification

--- a/index.html
+++ b/index.html
@@ -805,9 +805,8 @@ represented as a boolean value is produced as output.
 Let |publicKeyBytes| be the result of retrieving the
 public key bytes associated with the
 |options|.|verificationMethod| value as described in the
-[[[controller-document]]] specification,
-<a data-cite="controller-document#retrieve-verification-method">
-Section: Retrieve Verification Method</a>.
+<a data-cite="controller-document#retrieve-verification-method">Retrieve
+Verification Method</a> section of the [[[controller-document]]] specification.
             </li>
             <li>
 Let `verificationResult` be the result of applying the verification
@@ -1153,9 +1152,8 @@ represented as a boolean value is produced as output.
 Let |publicKeyBytes| be the result of retrieving the
 public key bytes associated with the
 |options|.|verificationMethod| value as described in the
-[[[controller-document]]] specification,
-<a data-cite="controller-document#retrieve-verification-method">
-Section: Retrieve Verification Method</a>.
+<a data-cite="controller-document#retrieve-verification-method">Retrieve
+Verification Method</a> section of the [[[controller-document]]] specification.
             </li>
             <li>
 Let `verificationResult` be the result of applying the verification
@@ -2200,9 +2198,8 @@ represented as a boolean value is produced as output.
 Let |publicKeyBytes| be the result of retrieving the
 public key bytes associated with the
 |options|.|verificationMethod| value as described in the
-[[[controller-document]]] specification,
-<a data-cite="controller-document#retrieve-verification-method">
-Section: Retrieve Verification Method</a>.
+<a data-cite="controller-document#retrieve-verification-method">Retrieve
+Verification Method</a> section of the [[[controller-document]]] specification.
               </li>
               <li>
 Let `verificationResult` be the result of applying the verification


### PR DESCRIPTION
This *editorial* PR addresses issue https://github.com/w3c/vc-di-eddsa/issues/108#issuecomment-2627706205 by updating this document with proper references and text on obtaining key material.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-eddsa/pull/109.html" title="Last updated on Jan 31, 2025, 10:39 PM UTC (33bad31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/109/ddc86db...Wind4Greg:33bad31.html" title="Last updated on Jan 31, 2025, 10:39 PM UTC (33bad31)">Diff</a>