### PR TITLE
Added the standard errata management

### DIFF
--- a/errata.html
+++ b/errata.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+  <!--
+    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
+    form 'w3c/XXX', although there are groups that have their own owner for their repository.
+  -->
+  <head data-githubrepo="w3c/vc-di-eddsa">
+    <meta charset="UTF-8">
+    <title>Open Errata for the Data Integrity EdDSA Cryptosuites v1.0</title>
+    <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
+    <script src="https://www.w3.org/scripts/jquery/1.11/jquery.min.js"></script>
+    <script src="https://w3c.github.io/display_errata/assets/moment.min.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
+    <script src="https://www.w3.org/scripts/underscore/1.8/underscore-min.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
+
+    <style type="text/css">
+      .todo {
+        background-color: yellow
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <p class="banner"><a accesskey="W" href="/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
+      <br />
+      <h1 class="title">Open Errata for the Data Integrity EdDSA Cryptosuites v1.0</h1>
+      <dl>
+        <dt>Latest errata update:</dt>
+        <dd><span id="date"></span></dd>
+        <dt>Number of recorded errata:</dt>
+        <dd><span id="number"></span></dd>
+        <dt>Link to all errata:</dt>
+        <dd><span id="errata_link"></span></dd>
+      </dl>
+
+      <section data-notoc>
+        <h1>How to Submit an Erratum?</h1>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/vc-di-eddsa/issues/">issue list of the group‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <ul>
+          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>PossibleErratum</code>”. One erratum might have several labels.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>PossibleErratum</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>Issues labeled as “<code>Errata</code>” are displayed below.</li>
+          <li>If the community rejects the issue as an erratum, the issue should be closed (but they will not be removed from the listing below, to ensure a historical record).</li>
+          <li>Each errata may also be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        </ul>
+
+        <p>This report contains a reference to all open issues with the label <code>Errata</code>.</p>
+
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a href="mailto:ivan@w3.org">ivan</a>.</p>
+      </section>
+    </header>
+
+    <div class="toc" id="toc"></div>
+
+    <main>
+      <!-- The data-erratalabel should include one label that filters the errata -->
+      <section data-nolabel>
+        <h1>Open Errata on the “Data Integrity EdDSA Cryptosuites v1.0”</h1>
+        <dl>
+          <dt>Latest Published Version:</dt>
+          <dd><a href="https://www.w3.org/TR/vc-di-eddsa/">https://www.w3.org/TR/vc-di-eddsa/</a></dd>
+          <dt>Editor’s draft:</dt>
+          <dd><a href="https://w3c.github.io/vc-di-eddsa/">https://w3c.github.io/vc-di-eddsa/</a></dd>
+          <dt>Latest Publication Date:</dt>
+          <dd>15 May 2025</dd>
+        </dl>
+        <section id="first">
+          <h2>Substantive Issues</h2>
+        </section>
+        <section id="last">
+          <h2>Editorial Issues</h2>
+        </section>
+      </section>
+    </main>
+
+    <footer>
+      <address><a href="mailto:ivan@w3.org" class=''>ivan</a>, &lt;ivan@w3.org&gt;, (W3C)</address>
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © <span class="todo">2025</span>
+        World Wide Web Consortium.
+        W3C® <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and
+        <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a>
+        rules apply.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
 
         // if there a publicly available Editor's Draft, this is the link
         edDraftURI: "https://w3c.github.io/vc-di-eddsa/",
+        errata: "https://w3c.github.io/vc-di-eddsa/errata.html",
         //latestVersion: "https://www.w3.org/community/reports/credentials/CG-FINAL-di-eddsa-2020-20220724/",
 
         // if this is a LCWD, uncomment and set the end of its review period


### PR DESCRIPTION
I have reused the errata management used for DID which, in turn, originates from the standard W3C practice these days.

If and when merged, the `Errata` and `PossibleErratum` labels must be added to the repo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/pull/114.html" title="Last updated on Apr 25, 2025, 7:35 AM UTC (ee36a31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-eddsa/114/fdea749...ee36a31.html" title="Last updated on Apr 25, 2025, 7:35 AM UTC (ee36a31)">Diff</a>