### PR TITLE
Update echidna

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,5 +16,5 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
           W3C_WG_DECISION_URL: https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-04-12-vcwg#resolution1
           W3C_BUILD_OVERRIDE: |
-             shortName: vc-di-eddsa
-             specStatus: CRD
+             shortName: vc-di-eddsa-1.1
+             specStatus: WD


### PR DESCRIPTION
The workflow must be activated after merge. The value of the repository token has been renewed for the new short name.